### PR TITLE
Added 'type' props to switch button

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ import 'vue-material/dist/vue-material.css'
 
 // OR
 
-var Vue = require(vue')
-var VueMaterial = require(vue-material')
+var Vue = require('vue')
+var VueMaterial = require('vue-material')
 require('vue-material/dist/vue-material.css')
 ```
 

--- a/docs/src/pages/components/Switch.vue
+++ b/docs/src/pages/components/Switch.vue
@@ -36,6 +36,16 @@
           <md-switch v-model="checked7" id="my-test7" name="my-test7" class="md-primary" disabled>Light Blue Primary Color Disabled</md-switch>
         </div>
       </demo-example>
+
+      <demo-example label="Typed">
+        <form @click.stop.prevent="submit">
+          <md-switch v-model="checked8" id="my-test8" name="my-test8">Submit (default)</md-switch>
+        </form>
+
+        <div>
+          <md-switch type="button" v-model="checked9" id="my-test9" name="my-test9" class="md-primary">Button</md-switch>
+        </div>
+      </demo-example>
     </div>
 
     <div slot="code">
@@ -67,6 +77,28 @@
 &lt;/div&gt;
         </code-block>
       </demo-example>
+
+      <demo-example label="Typed">
+        <code-block lang="xml">
+&lt;form @click.stop.prevent=&quot;submit&quot;&gt;
+  &lt;md-switch v-model=&quot;checked8&quot; id=&quot;my-test8&quot; name=&quot;my-test8&quot;&gt;Submit (default)&lt;/md-switch&gt;
+&lt;/form&gt;
+
+&lt;div&gt;
+  &lt;md-switch type=&quot;button&quot; v-model=&quot;checked9&quot; id=&quot;my-test9&quot; name=&quot;my-test9&quot; class=&quot;md-primary&quot;&gt;Button&lt;/md-switch&gt;
+&lt;/div&gt;
+        </code-block>
+
+        <code-block lang="javascript">
+export default {
+  methods: {
+    submit(e) {
+      alert('Default switch submits form');
+    }
+  }
+};
+        </code-block>
+      </demo-example>
     </div>
 
     <div slot="api">
@@ -86,8 +118,17 @@
         checked4: true,
         checked5: true,
         checked6: true,
-        checked7: true
+        checked7: true,
+        checked8: true,
+        checked9: true,
+        checked10: true
       };
+    },
+
+    methods: {
+      submit(e) {
+        alert('Default switch submits form');
+      }
     }
   };
 </script>

--- a/docs/src/pages/components/Switch.vue
+++ b/docs/src/pages/components/Switch.vue
@@ -38,12 +38,12 @@
       </demo-example>
 
       <demo-example label="Typed">
-        <form @click.stop.prevent="submit">
-          <md-switch v-model="checked8" id="my-test8" name="my-test8">Submit (default)</md-switch>
-        </form>
+        <md-switch v-model="checked8" id="my-test8" name="my-test8">Button (default)</md-switch>
 
         <div>
-          <md-switch type="button" v-model="checked9" id="my-test9" name="my-test9" class="md-primary">Button</md-switch>
+          <form @click.stop.prevent="submit">
+            <md-switch type="submit" v-model="checked9" id="my-test9" name="my-test9" class="md-primary">Submit</md-switch>
+          </form>
         </div>
       </demo-example>
     </div>
@@ -80,20 +80,20 @@
 
       <demo-example label="Typed">
         <code-block lang="xml">
-&lt;form @click.stop.prevent=&quot;submit&quot;&gt;
-  &lt;md-switch v-model=&quot;checked8&quot; id=&quot;my-test8&quot; name=&quot;my-test8&quot;&gt;Submit (default)&lt;/md-switch&gt;
-&lt;/form&gt;
-
 &lt;div&gt;
-  &lt;md-switch type=&quot;button&quot; v-model=&quot;checked9&quot; id=&quot;my-test9&quot; name=&quot;my-test9&quot; class=&quot;md-primary&quot;&gt;Button&lt;/md-switch&gt;
+  &lt;md-switch v-model=&quot;checked8&quot; id=&quot;my-test8&quot; name=&quot;my-test8&quot; class=&quot;md-primary&quot;&gt;Button (default)&lt;/md-switch&gt;
 &lt;/div&gt;
+
+&lt;form @click.stop.prevent=&quot;submit&quot;&gt;
+  &lt;md-switch type=&quot;submit&quot; v-model=&quot;checked9&quot; id=&quot;my-test9&quot; name=&quot;my-test9&quot;&gt;Submit&lt;/md-switch&gt;
+&lt;/form&gt;
         </code-block>
 
         <code-block lang="javascript">
 export default {
   methods: {
     submit(e) {
-      alert('Default switch submits form');
+      alert('This switch submits the form');
     }
   }
 };
@@ -126,8 +126,8 @@ export default {
     },
 
     methods: {
-      submit(e) {
-        alert('Default switch submits form');
+      submit() {
+        alert('This switch submits the form');
       }
     }
   };

--- a/src/components/mdSwitch/mdSwitch.vue
+++ b/src/components/mdSwitch/mdSwitch.vue
@@ -25,7 +25,10 @@
       value: Boolean,
       id: String,
       disabled: Boolean,
-      type: String
+      type: {
+        type: String,
+        default: 'button'
+      }
     },
     data() {
       return {

--- a/src/components/mdSwitch/mdSwitch.vue
+++ b/src/components/mdSwitch/mdSwitch.vue
@@ -3,7 +3,7 @@
     <div class="md-switch-container" @click="toggleSwitch">
       <div class="md-switch-thumb" :style="styles" v-md-ink-ripple="disabled">
         <input type="checkbox" :name="name" :id="id" :disabled="disabled" :value="value">
-        <button class="md-switch-holder"></button>
+        <button :type="type" class="md-switch-holder"></button>
       </div>
     </div>
 
@@ -24,7 +24,8 @@
       name: String,
       value: Boolean,
       id: String,
-      disabled: Boolean
+      disabled: Boolean,
+      type: String
     },
     data() {
       return {


### PR DESCRIPTION
Hi, 
as button tag is set to `type="submit"` by default, it causes problems when the switch is placed in a `<form>`.
I thought that passing `type` (if needed) to the `md-switch` could be useful?

Thanks for your work!