### PR TITLE
use the internal value of md_input to set the value of the container

### DIFF
--- a/src/components/mdInputContainer/common.js
+++ b/src/components/mdInputContainer/common.js
@@ -29,7 +29,7 @@ export default {
       this.parentContainer.counterLength = this.maxlength;
     },
     setParentValue() {
-      this.parentContainer.setValue(this.$el.value);
+      this.parentContainer.setValue(this.value);
     },
     setParentDisabled() {
       this.parentContainer.isDisabled = this.disabled;


### PR DESCRIPTION
i think the problem is: this.$el.value is sometime not set fast enough und you have to use vue.nextTick() https://vuejs.org/v2/api/#Vue-nextTick if you have to use the value of the input