### PR TITLE
Add extra "align" directions that do not cover menu trigger.

### DIFF
--- a/docs/src/pages/components/Menu.vue
+++ b/docs/src/pages/components/Menu.vue
@@ -53,7 +53,6 @@
           </md-menu-content>
         </md-menu>
 
-
         <md-menu md-direction="bottom left align">
           <md-button md-menu-trigger>Bottom Left Align</md-button>
 

--- a/docs/src/pages/components/Menu.vue
+++ b/docs/src/pages/components/Menu.vue
@@ -245,6 +245,46 @@
     &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
   &lt;/md-menu-content&gt;
 &lt;/md-menu&gt;
+
+&lt;md-menu md-direction=&quot;bottom right align&quot;&gt;
+  &lt;md-button md-menu-trigger&gt;Bottom Right Align&lt;/md-button&gt;
+
+  &lt;md-menu-content&gt;
+    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+  &lt;/md-menu-content&gt;
+&lt;/md-menu&gt;
+
+&lt;md-menu md-direction=&quot;bottom left align&quot;&gt;
+  &lt;md-button md-menu-trigger&gt;Bottom Left Align&lt;/md-button&gt;
+
+  &lt;md-menu-content&gt;
+    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+  &lt;/md-menu-content&gt;
+&lt;/md-menu&gt;
+
+&lt;md-menu md-direction=&quot;top left align&quot;&gt;
+  &lt;md-button md-menu-trigger&gt;Top Left Align&lt;/md-button&gt;
+
+  &lt;md-menu-content&gt;
+    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+  &lt;/md-menu-content&gt;
+&lt;/md-menu&gt;
+
+&lt;md-menu md-direction=&quot;top right align&quot;&gt;
+  &lt;md-button md-menu-trigger&gt;Top Right Align&lt;/md-button&gt;
+
+  &lt;md-menu-content&gt;
+    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+  &lt;/md-menu-content&gt;
+&lt;/md-menu&gt;
 </code-block>
       </demo-example>
 

--- a/docs/src/pages/components/Menu.vue
+++ b/docs/src/pages/components/Menu.vue
@@ -42,19 +42,11 @@
             <md-menu-item>My Item 3</md-menu-item>
           </md-menu-content>
         </md-menu>
+      </demo-example>
 
-        <md-menu md-direction="bottom right align">
-          <md-button md-menu-trigger>Bottom Right Align</md-button>
-
-          <md-menu-content>
-            <md-menu-item>My Item 1</md-menu-item>
-            <md-menu-item>My Item 2</md-menu-item>
-            <md-menu-item>My Item 3</md-menu-item>
-          </md-menu-content>
-        </md-menu>
-
-        <md-menu md-direction="bottom left align">
-          <md-button md-menu-trigger>Bottom Left Align</md-button>
+      <demo-example label="Alignment">
+        <md-menu>
+          <md-button md-menu-trigger>Default</md-button>
 
           <md-menu-content>
             <md-menu-item>My Item 1</md-menu-item>
@@ -63,8 +55,8 @@
           </md-menu-content>
         </md-menu>
 
-        <md-menu md-direction="top left align">
-          <md-button md-menu-trigger>Top Left Align</md-button>
+        <md-menu md-align-trigger>
+          <md-button md-menu-trigger>Align trigger</md-button>
 
           <md-menu-content>
             <md-menu-item>My Item 1</md-menu-item>
@@ -72,9 +64,8 @@
             <md-menu-item>My Item 3</md-menu-item>
           </md-menu-content>
         </md-menu>
-
-        <md-menu md-direction="top right align">
-          <md-button md-menu-trigger>Top Right Align</md-button>
+        <md-menu :md-offset-x="154" md-offset-y="12">
+          <md-button md-menu-trigger>Custom offset</md-button>
 
           <md-menu-content>
             <md-menu-item>My Item 1</md-menu-item>

--- a/docs/src/pages/components/Menu.vue
+++ b/docs/src/pages/components/Menu.vue
@@ -205,169 +205,169 @@
 
     <div slot="code">
       <demo-example label="Directions">
-        <code-block lang="xml">
-          &lt;md-menu&gt;
-          &lt;md-button md-menu-trigger&gt;Bottom Right&lt;/md-button&gt;
+<code-block lang="xml">
+&lt;md-menu&gt;
+  &lt;md-button md-menu-trigger&gt;Bottom Right&lt;/md-button&gt;
 
-          &lt;md-menu-content&gt;
-          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-          &lt;/md-menu-content&gt;
-          &lt;/md-menu&gt;
+  &lt;md-menu-content&gt;
+    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+  &lt;/md-menu-content&gt;
+&lt;/md-menu&gt;
 
-          &lt;md-menu md-direction=&quot;bottom left&quot;&gt;
-          &lt;md-button md-menu-trigger&gt;Bottom Left&lt;/md-button&gt;
+&lt;md-menu md-direction=&quot;bottom left&quot;&gt;
+  &lt;md-button md-menu-trigger&gt;Bottom Left&lt;/md-button&gt;
 
-          &lt;md-menu-content&gt;
-          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-          &lt;md-menu-item disabled&gt;My Item 3&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 4&lt;/md-menu-item&gt;
-          &lt;/md-menu-content&gt;
-          &lt;/md-menu&gt;
+  &lt;md-menu-content&gt;
+    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+    &lt;md-menu-item disabled&gt;My Item 3&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 4&lt;/md-menu-item&gt;
+  &lt;/md-menu-content&gt;
+&lt;/md-menu&gt;
 
-          &lt;md-menu md-direction=&quot;top left&quot;&gt;
-          &lt;md-button md-menu-trigger&gt;Top Left&lt;/md-button&gt;
+&lt;md-menu md-direction=&quot;top left&quot;&gt;
+  &lt;md-button md-menu-trigger&gt;Top Left&lt;/md-button&gt;
 
-          &lt;md-menu-content&gt;
-          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-          &lt;/md-menu-content&gt;
-          &lt;/md-menu&gt;
+  &lt;md-menu-content&gt;
+    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+  &lt;/md-menu-content&gt;
+&lt;/md-menu&gt;
 
-          &lt;md-menu md-direction=&quot;top right&quot;&gt;
-          &lt;md-button md-menu-trigger&gt;Top Right&lt;/md-button&gt;
+&lt;md-menu md-direction=&quot;top right&quot;&gt;
+  &lt;md-button md-menu-trigger&gt;Top Right&lt;/md-button&gt;
 
-          &lt;md-menu-content&gt;
-          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-          &lt;/md-menu-content&gt;
-          &lt;/md-menu&gt;
-        </code-block>
+  &lt;md-menu-content&gt;
+    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+  &lt;/md-menu-content&gt;
+&lt;/md-menu&gt;
+</code-block>
       </demo-example>
 
       <demo-example label="Sizes">
-        <code-block lang="xml">
-          &lt;md-menu&gt;
-          &lt;md-button md-menu-trigger&gt;Default&lt;/md-button&gt;
+<code-block lang="xml">
+&lt;md-menu&gt;
+  &lt;md-button md-menu-trigger&gt;Default&lt;/md-button&gt;
 
-          &lt;md-menu-content&gt;
-          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-          &lt;/md-menu-content&gt;
-          &lt;/md-menu&gt;
+  &lt;md-menu-content&gt;
+    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+  &lt;/md-menu-content&gt;
+&lt;/md-menu&gt;
 
-          &lt;md-menu md-size=&quot;1&quot;&gt;
-          &lt;md-button md-menu-trigger&gt;Size 1&lt;/md-button&gt;
+&lt;md-menu md-size=&quot;1&quot;&gt;
+  &lt;md-button md-menu-trigger&gt;Size 1&lt;/md-button&gt;
 
-          &lt;md-menu-content&gt;
-          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-          &lt;/md-menu-content&gt;
-          &lt;/md-menu&gt;
+  &lt;md-menu-content&gt;
+    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+  &lt;/md-menu-content&gt;
+&lt;/md-menu&gt;
 
-          &lt;md-menu md-size=&quot;2&quot;&gt;
-          &lt;md-button md-menu-trigger&gt;Size 2&lt;/md-button&gt;
+&lt;md-menu md-size=&quot;2&quot;&gt;
+  &lt;md-button md-menu-trigger&gt;Size 2&lt;/md-button&gt;
 
-          &lt;md-menu-content&gt;
-          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-          &lt;/md-menu-content&gt;
-          &lt;/md-menu&gt;
+  &lt;md-menu-content&gt;
+    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+  &lt;/md-menu-content&gt;
+&lt;/md-menu&gt;
 
-          &lt;md-menu md-size=&quot;4&quot;&gt;
-          &lt;md-button md-menu-trigger&gt;Size 4&lt;/md-button&gt;
+&lt;md-menu md-size=&quot;4&quot;&gt;
+  &lt;md-button md-menu-trigger&gt;Size 4&lt;/md-button&gt;
 
-          &lt;md-menu-content&gt;
-          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-          &lt;/md-menu-content&gt;
-          &lt;/md-menu&gt;
+  &lt;md-menu-content&gt;
+    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+  &lt;/md-menu-content&gt;
+&lt;/md-menu&gt;
 
-          &lt;md-menu md-size=&quot;5&quot;&gt;
-          &lt;md-button md-menu-trigger&gt;Size 5&lt;/md-button&gt;
+&lt;md-menu md-size=&quot;5&quot;&gt;
+  &lt;md-button md-menu-trigger&gt;Size 5&lt;/md-button&gt;
 
-          &lt;md-menu-content&gt;
-          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-          &lt;/md-menu-content&gt;
-          &lt;/md-menu&gt;
+  &lt;md-menu-content&gt;
+    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+  &lt;/md-menu-content&gt;
+&lt;/md-menu&gt;
 
-          &lt;md-menu md-size=&quot;7&quot;&gt;
-          &lt;md-button md-menu-trigger&gt;Size 7&lt;/md-button&gt;
+&lt;md-menu md-size=&quot;7&quot;&gt;
+  &lt;md-button md-menu-trigger&gt;Size 7&lt;/md-button&gt;
 
-          &lt;md-menu-content&gt;
-          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-          &lt;/md-menu-content&gt;
-          &lt;/md-menu&gt;
-        </code-block>
+  &lt;md-menu-content&gt;
+    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+  &lt;/md-menu-content&gt;
+&lt;/md-menu&gt;
+</code-block>
       </demo-example>
 
       <demo-example label="List Icons">
-        <code-block lang="xml">
-          &lt;md-menu&gt;
-          &lt;md-button class=&quot;md-icon-button&quot; md-menu-trigger&gt;
-          &lt;md-icon&gt;more_vert&lt;/md-icon&gt;
-          &lt;/md-button&gt;
+<code-block lang="xml">
+&lt;md-menu&gt;
+  &lt;md-button class=&quot;md-icon-button&quot; md-menu-trigger&gt;
+    &lt;md-icon&gt;more_vert&lt;/md-icon&gt;
+  &lt;/md-button&gt;
 
-          &lt;md-menu-content&gt;
-          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-          &lt;/md-menu-content&gt;
-          &lt;/md-menu&gt;
+  &lt;md-menu-content&gt;
+    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+  &lt;/md-menu-content&gt;
+&lt;/md-menu&gt;
 
-          &lt;md-menu md-size=&quot;4&quot;&gt;
-          &lt;md-button class=&quot;md-icon-button&quot; md-menu-trigger&gt;
-          &lt;md-icon&gt;phone&lt;/md-icon&gt;
-          &lt;/md-button&gt;
+&lt;md-menu md-size=&quot;4&quot;&gt;
+  &lt;md-button class=&quot;md-icon-button&quot; md-menu-trigger&gt;
+    &lt;md-icon&gt;phone&lt;/md-icon&gt;
+  &lt;/md-button&gt;
 
-          &lt;md-menu-content&gt;
-          &lt;md-menu-item&gt;
-          &lt;md-icon&gt;phone&lt;/md-icon&gt;
-          &lt;span&gt;My Item 1&lt;/span&gt;
-          &lt;/md-menu-item&gt;
+  &lt;md-menu-content&gt;
+    &lt;md-menu-item&gt;
+      &lt;md-icon&gt;phone&lt;/md-icon&gt;
+      &lt;span&gt;My Item 1&lt;/span&gt;
+    &lt;/md-menu-item&gt;
 
-          &lt;md-menu-item&gt;
-          &lt;md-icon&gt;phone&lt;/md-icon&gt;
-          &lt;span&gt;My Item 2&lt;/span&gt;
-          &lt;/md-menu-item&gt;
+    &lt;md-menu-item&gt;
+      &lt;md-icon&gt;phone&lt;/md-icon&gt;
+      &lt;span&gt;My Item 2&lt;/span&gt;
+    &lt;/md-menu-item&gt;
 
-          &lt;md-menu-item&gt;
-          &lt;md-icon&gt;phone&lt;/md-icon&gt;
-          &lt;span&gt;My Item 3&lt;/span&gt;
-          &lt;/md-menu-item&gt;
-          &lt;/md-menu-content&gt;
-          &lt;/md-menu&gt;
+    &lt;md-menu-item&gt;
+      &lt;md-icon&gt;phone&lt;/md-icon&gt;
+      &lt;span&gt;My Item 3&lt;/span&gt;
+    &lt;/md-menu-item&gt;
+  &lt;/md-menu-content&gt;
+&lt;/md-menu&gt;
 
-          &lt;md-menu md-direction=&quot;bottom left&quot; md-size=&quot;4&quot;&gt;
-          &lt;md-button class=&quot;md-icon-button&quot; md-menu-trigger&gt;
-          &lt;md-icon&gt;near_me&lt;/md-icon&gt;
-          &lt;/md-button&gt;
+&lt;md-menu md-direction=&quot;bottom left&quot; md-size=&quot;4&quot;&gt;
+  &lt;md-button class=&quot;md-icon-button&quot; md-menu-trigger&gt;
+    &lt;md-icon&gt;near_me&lt;/md-icon&gt;
+  &lt;/md-button&gt;
 
-          &lt;md-menu-content&gt;
-          &lt;md-menu-item&gt;
-          &lt;span&gt;Find on map&lt;/span&gt;
-          &lt;md-icon&gt;near_me&lt;/md-icon&gt;
-          &lt;/md-menu-item&gt;
+  &lt;md-menu-content&gt;
+    &lt;md-menu-item&gt;
+      &lt;span&gt;Find on map&lt;/span&gt;
+      &lt;md-icon&gt;near_me&lt;/md-icon&gt;
+    &lt;/md-menu-item&gt;
 
-          &lt;md-menu-item&gt;
-          &lt;span&gt;Call&lt;/span&gt;
-          &lt;md-icon&gt;phone&lt;/md-icon&gt;
-          &lt;/md-menu-item&gt;
-          &lt;/md-menu-content&gt;
-          &lt;/md-menu&gt;
-        </code-block>
+    &lt;md-menu-item&gt;
+      &lt;span&gt;Call&lt;/span&gt;
+      &lt;md-icon&gt;phone&lt;/md-icon&gt;
+    &lt;/md-menu-item&gt;
+  &lt;/md-menu-content&gt;
+&lt;/md-menu&gt;
+</code-block>
       </demo-example>
     </div>
 

--- a/docs/src/pages/components/Menu.vue
+++ b/docs/src/pages/components/Menu.vue
@@ -236,19 +236,13 @@
     &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
   &lt;/md-menu-content&gt;
 &lt;/md-menu&gt;
+</code-block>
+      </demo-example>
 
-&lt;md-menu md-direction=&quot;bottom right align&quot;&gt;
-  &lt;md-button md-menu-trigger&gt;Bottom Right Align&lt;/md-button&gt;
-
-  &lt;md-menu-content&gt;
-    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-  &lt;/md-menu-content&gt;
-&lt;/md-menu&gt;
-
-&lt;md-menu md-direction=&quot;bottom left align&quot;&gt;
-  &lt;md-button md-menu-trigger&gt;Bottom Left Align&lt;/md-button&gt;
+      <demo-example label="Alignments">
+<code-block lang="xml">
+&lt;md-menu&gt;
+  &lt;md-button md-menu-trigger&gt;Default&lt;/md-button&gt;
 
   &lt;md-menu-content&gt;
     &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
@@ -257,8 +251,8 @@
   &lt;/md-menu-content&gt;
 &lt;/md-menu&gt;
 
-&lt;md-menu md-direction=&quot;top left align&quot;&gt;
-  &lt;md-button md-menu-trigger&gt;Top Left Align&lt;/md-button&gt;
+&lt;md-menu md-align-trigger&gt;
+  &lt;md-button md-menu-trigger&gt;Align trigger&lt;/md-button&gt;
 
   &lt;md-menu-content&gt;
     &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
@@ -267,8 +261,8 @@
   &lt;/md-menu-content&gt;
 &lt;/md-menu&gt;
 
-&lt;md-menu md-direction=&quot;top right align&quot;&gt;
-  &lt;md-button md-menu-trigger&gt;Top Right Align&lt;/md-button&gt;
+&lt;md-menu :md-offset-x=&quot;154&quot; md-offset-y=&quot;12&quot;&gt;
+  &lt;md-button md-menu-trigger&gt;Custom offset&lt;/md-button&gt;
 
   &lt;md-menu-content&gt;
     &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;

--- a/docs/src/pages/components/Menu.vue
+++ b/docs/src/pages/components/Menu.vue
@@ -44,7 +44,7 @@
         </md-menu>
       </demo-example>
 
-      <demo-example label="Alignment">
+      <demo-example label="Alignments">
         <md-menu>
           <md-button md-menu-trigger>Default</md-button>
 

--- a/docs/src/pages/components/Menu.vue
+++ b/docs/src/pages/components/Menu.vue
@@ -42,6 +42,47 @@
             <md-menu-item>My Item 3</md-menu-item>
           </md-menu-content>
         </md-menu>
+
+        <md-menu md-direction="bottom right align">
+          <md-button md-menu-trigger>Bottom Right Align</md-button>
+
+          <md-menu-content>
+            <md-menu-item>My Item 1</md-menu-item>
+            <md-menu-item>My Item 2</md-menu-item>
+            <md-menu-item>My Item 3</md-menu-item>
+          </md-menu-content>
+        </md-menu>
+
+
+        <md-menu md-direction="bottom left align">
+          <md-button md-menu-trigger>Bottom Left Align</md-button>
+
+          <md-menu-content>
+            <md-menu-item>My Item 1</md-menu-item>
+            <md-menu-item>My Item 2</md-menu-item>
+            <md-menu-item>My Item 3</md-menu-item>
+          </md-menu-content>
+        </md-menu>
+
+        <md-menu md-direction="top left align">
+          <md-button md-menu-trigger>Top Left Align</md-button>
+
+          <md-menu-content>
+            <md-menu-item>My Item 1</md-menu-item>
+            <md-menu-item>My Item 2</md-menu-item>
+            <md-menu-item>My Item 3</md-menu-item>
+          </md-menu-content>
+        </md-menu>
+
+        <md-menu md-direction="top right align">
+          <md-button md-menu-trigger>Top Right Align</md-button>
+
+          <md-menu-content>
+            <md-menu-item>My Item 1</md-menu-item>
+            <md-menu-item>My Item 2</md-menu-item>
+            <md-menu-item>My Item 3</md-menu-item>
+          </md-menu-content>
+        </md-menu>
       </demo-example>
 
       <demo-example label="Sizes">
@@ -164,169 +205,169 @@
 
     <div slot="code">
       <demo-example label="Directions">
-<code-block lang="xml">
-&lt;md-menu&gt;
-  &lt;md-button md-menu-trigger&gt;Bottom Right&lt;/md-button&gt;
+        <code-block lang="xml">
+          &lt;md-menu&gt;
+          &lt;md-button md-menu-trigger&gt;Bottom Right&lt;/md-button&gt;
 
-  &lt;md-menu-content&gt;
-    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-  &lt;/md-menu-content&gt;
-&lt;/md-menu&gt;
+          &lt;md-menu-content&gt;
+          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+          &lt;/md-menu-content&gt;
+          &lt;/md-menu&gt;
 
-&lt;md-menu md-direction=&quot;bottom left&quot;&gt;
-  &lt;md-button md-menu-trigger&gt;Bottom Left&lt;/md-button&gt;
+          &lt;md-menu md-direction=&quot;bottom left&quot;&gt;
+          &lt;md-button md-menu-trigger&gt;Bottom Left&lt;/md-button&gt;
 
-  &lt;md-menu-content&gt;
-    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-    &lt;md-menu-item disabled&gt;My Item 3&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 4&lt;/md-menu-item&gt;
-  &lt;/md-menu-content&gt;
-&lt;/md-menu&gt;
+          &lt;md-menu-content&gt;
+          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+          &lt;md-menu-item disabled&gt;My Item 3&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 4&lt;/md-menu-item&gt;
+          &lt;/md-menu-content&gt;
+          &lt;/md-menu&gt;
 
-&lt;md-menu md-direction=&quot;top left&quot;&gt;
-  &lt;md-button md-menu-trigger&gt;Top Left&lt;/md-button&gt;
+          &lt;md-menu md-direction=&quot;top left&quot;&gt;
+          &lt;md-button md-menu-trigger&gt;Top Left&lt;/md-button&gt;
 
-  &lt;md-menu-content&gt;
-    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-  &lt;/md-menu-content&gt;
-&lt;/md-menu&gt;
+          &lt;md-menu-content&gt;
+          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+          &lt;/md-menu-content&gt;
+          &lt;/md-menu&gt;
 
-&lt;md-menu md-direction=&quot;top right&quot;&gt;
-  &lt;md-button md-menu-trigger&gt;Top Right&lt;/md-button&gt;
+          &lt;md-menu md-direction=&quot;top right&quot;&gt;
+          &lt;md-button md-menu-trigger&gt;Top Right&lt;/md-button&gt;
 
-  &lt;md-menu-content&gt;
-    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-  &lt;/md-menu-content&gt;
-&lt;/md-menu&gt;
-</code-block>
+          &lt;md-menu-content&gt;
+          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+          &lt;/md-menu-content&gt;
+          &lt;/md-menu&gt;
+        </code-block>
       </demo-example>
 
       <demo-example label="Sizes">
-<code-block lang="xml">
-&lt;md-menu&gt;
-  &lt;md-button md-menu-trigger&gt;Default&lt;/md-button&gt;
+        <code-block lang="xml">
+          &lt;md-menu&gt;
+          &lt;md-button md-menu-trigger&gt;Default&lt;/md-button&gt;
 
-  &lt;md-menu-content&gt;
-    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-  &lt;/md-menu-content&gt;
-&lt;/md-menu&gt;
+          &lt;md-menu-content&gt;
+          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+          &lt;/md-menu-content&gt;
+          &lt;/md-menu&gt;
 
-&lt;md-menu md-size=&quot;1&quot;&gt;
-  &lt;md-button md-menu-trigger&gt;Size 1&lt;/md-button&gt;
+          &lt;md-menu md-size=&quot;1&quot;&gt;
+          &lt;md-button md-menu-trigger&gt;Size 1&lt;/md-button&gt;
 
-  &lt;md-menu-content&gt;
-    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-  &lt;/md-menu-content&gt;
-&lt;/md-menu&gt;
+          &lt;md-menu-content&gt;
+          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+          &lt;/md-menu-content&gt;
+          &lt;/md-menu&gt;
 
-&lt;md-menu md-size=&quot;2&quot;&gt;
-  &lt;md-button md-menu-trigger&gt;Size 2&lt;/md-button&gt;
+          &lt;md-menu md-size=&quot;2&quot;&gt;
+          &lt;md-button md-menu-trigger&gt;Size 2&lt;/md-button&gt;
 
-  &lt;md-menu-content&gt;
-    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-  &lt;/md-menu-content&gt;
-&lt;/md-menu&gt;
+          &lt;md-menu-content&gt;
+          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+          &lt;/md-menu-content&gt;
+          &lt;/md-menu&gt;
 
-&lt;md-menu md-size=&quot;4&quot;&gt;
-  &lt;md-button md-menu-trigger&gt;Size 4&lt;/md-button&gt;
+          &lt;md-menu md-size=&quot;4&quot;&gt;
+          &lt;md-button md-menu-trigger&gt;Size 4&lt;/md-button&gt;
 
-  &lt;md-menu-content&gt;
-    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-  &lt;/md-menu-content&gt;
-&lt;/md-menu&gt;
+          &lt;md-menu-content&gt;
+          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+          &lt;/md-menu-content&gt;
+          &lt;/md-menu&gt;
 
-&lt;md-menu md-size=&quot;5&quot;&gt;
-  &lt;md-button md-menu-trigger&gt;Size 5&lt;/md-button&gt;
+          &lt;md-menu md-size=&quot;5&quot;&gt;
+          &lt;md-button md-menu-trigger&gt;Size 5&lt;/md-button&gt;
 
-  &lt;md-menu-content&gt;
-    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-  &lt;/md-menu-content&gt;
-&lt;/md-menu&gt;
+          &lt;md-menu-content&gt;
+          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+          &lt;/md-menu-content&gt;
+          &lt;/md-menu&gt;
 
-&lt;md-menu md-size=&quot;7&quot;&gt;
-  &lt;md-button md-menu-trigger&gt;Size 7&lt;/md-button&gt;
+          &lt;md-menu md-size=&quot;7&quot;&gt;
+          &lt;md-button md-menu-trigger&gt;Size 7&lt;/md-button&gt;
 
-  &lt;md-menu-content&gt;
-    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-  &lt;/md-menu-content&gt;
-&lt;/md-menu&gt;
-</code-block>
+          &lt;md-menu-content&gt;
+          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+          &lt;/md-menu-content&gt;
+          &lt;/md-menu&gt;
+        </code-block>
       </demo-example>
 
       <demo-example label="List Icons">
-<code-block lang="xml">
-&lt;md-menu&gt;
-  &lt;md-button class=&quot;md-icon-button&quot; md-menu-trigger&gt;
-    &lt;md-icon&gt;more_vert&lt;/md-icon&gt;
-  &lt;/md-button&gt;
+        <code-block lang="xml">
+          &lt;md-menu&gt;
+          &lt;md-button class=&quot;md-icon-button&quot; md-menu-trigger&gt;
+          &lt;md-icon&gt;more_vert&lt;/md-icon&gt;
+          &lt;/md-button&gt;
 
-  &lt;md-menu-content&gt;
-    &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
-    &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
-  &lt;/md-menu-content&gt;
-&lt;/md-menu&gt;
+          &lt;md-menu-content&gt;
+          &lt;md-menu-item&gt;My Item 1&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 2&lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;My Item 3&lt;/md-menu-item&gt;
+          &lt;/md-menu-content&gt;
+          &lt;/md-menu&gt;
 
-&lt;md-menu md-size=&quot;4&quot;&gt;
-  &lt;md-button class=&quot;md-icon-button&quot; md-menu-trigger&gt;
-    &lt;md-icon&gt;phone&lt;/md-icon&gt;
-  &lt;/md-button&gt;
+          &lt;md-menu md-size=&quot;4&quot;&gt;
+          &lt;md-button class=&quot;md-icon-button&quot; md-menu-trigger&gt;
+          &lt;md-icon&gt;phone&lt;/md-icon&gt;
+          &lt;/md-button&gt;
 
-  &lt;md-menu-content&gt;
-    &lt;md-menu-item&gt;
-      &lt;md-icon&gt;phone&lt;/md-icon&gt;
-      &lt;span&gt;My Item 1&lt;/span&gt;
-    &lt;/md-menu-item&gt;
+          &lt;md-menu-content&gt;
+          &lt;md-menu-item&gt;
+          &lt;md-icon&gt;phone&lt;/md-icon&gt;
+          &lt;span&gt;My Item 1&lt;/span&gt;
+          &lt;/md-menu-item&gt;
 
-    &lt;md-menu-item&gt;
-      &lt;md-icon&gt;phone&lt;/md-icon&gt;
-      &lt;span&gt;My Item 2&lt;/span&gt;
-    &lt;/md-menu-item&gt;
+          &lt;md-menu-item&gt;
+          &lt;md-icon&gt;phone&lt;/md-icon&gt;
+          &lt;span&gt;My Item 2&lt;/span&gt;
+          &lt;/md-menu-item&gt;
 
-    &lt;md-menu-item&gt;
-      &lt;md-icon&gt;phone&lt;/md-icon&gt;
-      &lt;span&gt;My Item 3&lt;/span&gt;
-    &lt;/md-menu-item&gt;
-  &lt;/md-menu-content&gt;
-&lt;/md-menu&gt;
+          &lt;md-menu-item&gt;
+          &lt;md-icon&gt;phone&lt;/md-icon&gt;
+          &lt;span&gt;My Item 3&lt;/span&gt;
+          &lt;/md-menu-item&gt;
+          &lt;/md-menu-content&gt;
+          &lt;/md-menu&gt;
 
-&lt;md-menu md-direction=&quot;bottom left&quot; md-size=&quot;4&quot;&gt;
-  &lt;md-button class=&quot;md-icon-button&quot; md-menu-trigger&gt;
-    &lt;md-icon&gt;near_me&lt;/md-icon&gt;
-  &lt;/md-button&gt;
+          &lt;md-menu md-direction=&quot;bottom left&quot; md-size=&quot;4&quot;&gt;
+          &lt;md-button class=&quot;md-icon-button&quot; md-menu-trigger&gt;
+          &lt;md-icon&gt;near_me&lt;/md-icon&gt;
+          &lt;/md-button&gt;
 
-  &lt;md-menu-content&gt;
-    &lt;md-menu-item&gt;
-      &lt;span&gt;Find on map&lt;/span&gt;
-      &lt;md-icon&gt;near_me&lt;/md-icon&gt;
-    &lt;/md-menu-item&gt;
+          &lt;md-menu-content&gt;
+          &lt;md-menu-item&gt;
+          &lt;span&gt;Find on map&lt;/span&gt;
+          &lt;md-icon&gt;near_me&lt;/md-icon&gt;
+          &lt;/md-menu-item&gt;
 
-    &lt;md-menu-item&gt;
-      &lt;span&gt;Call&lt;/span&gt;
-      &lt;md-icon&gt;phone&lt;/md-icon&gt;
-    &lt;/md-menu-item&gt;
-  &lt;/md-menu-content&gt;
-&lt;/md-menu&gt;
-</code-block>
+          &lt;md-menu-item&gt;
+          &lt;span&gt;Call&lt;/span&gt;
+          &lt;md-icon&gt;phone&lt;/md-icon&gt;
+          &lt;/md-menu-item&gt;
+          &lt;/md-menu-content&gt;
+          &lt;/md-menu&gt;
+        </code-block>
       </demo-example>
     </div>
 

--- a/src/components/mdMenu/mdMenu.vue
+++ b/src/components/mdMenu/mdMenu.vue
@@ -22,6 +22,18 @@
         type: String,
         default: 'bottom right'
       },
+      mdAlignTrigger: {
+        type: Boolean,
+        default: false
+      },
+      mdOffsetX: {
+        type: [Number, String],
+        default: 0
+      },
+      mdOffsetY: {
+        type: [Number, String],
+        default: 0
+      },
       mdCloseOnSelect: {
         type: Boolean,
         default: true
@@ -69,9 +81,11 @@
         this.menuContent.classList.add('md-size-' + size);
       },
       addNewDirectionMenuContentClass(direction) {
-        this.menuContent.classList.add('md-direction-' + direction.replace(/ /g, '-'));
+        if (!this.mdAlignTrigger) {
+          this.menuContent.classList.add('md-direction-' + direction.replace(/ /g, '-'));
+        }
       },
-      getPosition(vertical, horizontal, align) {
+      getPosition(vertical, horizontal) {
         let menuTriggerRect = this.menuTrigger.getBoundingClientRect();
 
         let top = vertical === 'top'
@@ -82,7 +96,10 @@
           ? menuTriggerRect.left - this.menuContent.offsetWidth + menuTriggerRect.width
           : menuTriggerRect.left;
 
-        if (align) {
+        top += parseInt(this.mdOffsetY, 10);
+        left += parseInt(this.mdOffsetX, 10);
+
+        if (this.mdAlignTrigger) {
           if (vertical === 'top') {
             top -= menuTriggerRect.height;
           } else {
@@ -100,28 +117,12 @@
             position = this.getPosition('bottom', 'left');
             break;
 
-          case 'bottom left align':
-            position = this.getPosition('bottom', 'left', true);
-            break;
-
-          case 'bottom right align':
-            position = this.getPosition('bottom', 'right', true);
-            break;
-
           case 'top left':
             position = this.getPosition('top', 'left');
             break;
 
-          case 'top left align':
-            position = this.getPosition('top', 'left', true);
-            break;
-
           case 'top right':
             position = this.getPosition('top', 'right');
-            break;
-
-          case 'top right align':
-            position = this.getPosition('top', 'right', 'align');
             break;
 
           default:

--- a/src/components/mdMenu/mdMenu.vue
+++ b/src/components/mdMenu/mdMenu.vue
@@ -104,12 +104,8 @@
             position = this.getPosition('bottom', 'left', true);
             break;
 
-          case 'top right':
-            position = this.getPosition('top', 'right');
-            break;
-
-          case 'top right align':
-            position = this.getPosition('top', 'right', 'align');
+          case 'bottom right align':
+            position = this.getPosition('bottom', 'right', true);
             break;
 
           case 'top left':
@@ -120,8 +116,12 @@
             position = this.getPosition('top', 'left', true);
             break;
 
-          case 'bottom right align':
-            position = this.getPosition('bottom', 'right', true);
+          case 'top right':
+            position = this.getPosition('top', 'right');
+            break;
+
+          case 'top right align':
+            position = this.getPosition('top', 'right', 'align');
             break;
 
           default:

--- a/src/components/mdMenu/mdMenu.vue
+++ b/src/components/mdMenu/mdMenu.vue
@@ -63,80 +63,72 @@
         this.menuContent.classList.remove('md-size-' + size);
       },
       removeLastDirectionMenuContentClass(direction) {
-        this.menuContent.classList.remove('md-direction-' + direction.replace(' ', '-'));
+        this.menuContent.classList.remove('md-direction-' + direction.replace(/ /g, '-'));
       },
       addNewSizeMenuContentClass(size) {
         this.menuContent.classList.add('md-size-' + size);
       },
       addNewDirectionMenuContentClass(direction) {
-        this.menuContent.classList.add('md-direction-' + direction.replace(' ', '-'));
+        this.menuContent.classList.add('md-direction-' + direction.replace(/ /g, '-'));
       },
-      getBottomRightPos() {
+      getPosition(vertical, horizontal, align) {
         let menuTriggerRect = this.menuTrigger.getBoundingClientRect();
-        let position = {
-          top: menuTriggerRect.top,
-          left: menuTriggerRect.left
-        };
 
-        position = getInViewPosition(this.menuContent, position);
+        let top = vertical === 'top'
+          ? menuTriggerRect.top + menuTriggerRect.height - this.menuContent.offsetHeight
+          : menuTriggerRect.top;
 
-        return position;
-      },
-      getBottomLeftPos() {
-        let menuTriggerRect = this.menuTrigger.getBoundingClientRect();
-        let position = {
-          top: menuTriggerRect.top,
-          left: menuTriggerRect.left - this.menuContent.offsetWidth + menuTriggerRect.width
-        };
+        let left = horizontal === 'left'
+          ? menuTriggerRect.left - this.menuContent.offsetWidth + menuTriggerRect.width
+          : menuTriggerRect.left;
 
-        position = getInViewPosition(this.menuContent, position);
+        if (align) {
+          if (vertical === 'top') {
+            top -= menuTriggerRect.height;
+          } else {
+            top += menuTriggerRect.height;
+          }
+        }
 
-        return position;
-      },
-      getTopRightPos() {
-        let menuTriggerRect = this.menuTrigger.getBoundingClientRect();
-        let position = {
-          top: menuTriggerRect.top + menuTriggerRect.height - this.menuContent.offsetHeight,
-          left: menuTriggerRect.left
-        };
-
-        position = getInViewPosition(this.menuContent, position);
-
-        return position;
-      },
-      getTopLeftPos() {
-        let menuTriggerRect = this.menuTrigger.getBoundingClientRect();
-        let position = {
-          top: menuTriggerRect.top + menuTriggerRect.height - this.menuContent.offsetHeight,
-          left: menuTriggerRect.left - this.menuContent.offsetWidth + menuTriggerRect.width
-        };
-
-        position = getInViewPosition(this.menuContent, position);
-
-        return position;
+        return {top, left};
       },
       calculateMenuContentPos() {
         let position;
 
         switch (this.mdDirection) {
           case 'bottom left':
-            position = this.getBottomLeftPos();
+            position = this.getPosition('bottom', 'left');
+            break;
 
+          case 'bottom left align':
+            position = this.getPosition('bottom', 'left', true);
             break;
 
           case 'top right':
-            position = this.getTopRightPos();
+            position = this.getPosition('top', 'right');
+            break;
 
+          case 'top right align':
+            position = this.getPosition('top', 'right', 'align');
             break;
 
           case 'top left':
-            position = this.getTopLeftPos();
+            position = this.getPosition('top', 'left');
+            break;
 
+          case 'top left align':
+            position = this.getPosition('top', 'left', true);
+            break;
+
+          case 'bottom right align':
+            position = this.getPosition('bottom', 'right', true);
             break;
 
           default:
-            position = this.getBottomRightPos();
+            position = this.getPosition('bottom', 'right');
         }
+
+        position = getInViewPosition(this.menuContent, position);
 
         this.menuContent.style.top = position.top + 'px';
         this.menuContent.style.left = position.left + 'px';


### PR DESCRIPTION
I needed a menu list that do not cover menu trigger. You can see how it should look at https://material.google.com/components/menus.html. I didn't bother to create issue for that.

![components_menus_usage3do](https://cloud.githubusercontent.com/assets/510431/20579984/10be6638-b1d0-11e6-89f3-da5e2710d1b8.png)

I think the code is quite obvious but I have one concern about the API. I was wondering it it would be better to just add another direction constant strings (which I did) or maybe as another prop called "align" for this purpose. Also if you have better name for this feature I'm open for the change.
