### PR TITLE
unregisterMouseEvent accepts the element as parameter

### DIFF
--- a/src/core/components/mdInkRipple/index.js
+++ b/src/core/components/mdInkRipple/index.js
@@ -8,8 +8,8 @@ export default function install(Vue) {
   let registeredMouseFunction;
   let referenceElement;
 
-  let unregisterMouseEvent = () => {
-    referenceElement.removeEventListener('mousedown', registeredMouseFunction);
+  let unregisterMouseEvent = (el = referenceElement) => {
+    el.removeEventListener('mousedown', registeredMouseFunction);
   };
 
   let registerMouseEvent = (element, holder) => {


### PR DESCRIPTION
The mdInkRipple-directive passes the elemnt as an param. But the param option is missing.
https://github.com/marcosmoura/vue-material/blob/master/src/core/components/mdInkRipple/index.js#L114

It's fix for #114 not #109 🙈 