### PR TITLE
[update] Backdrop component classes customization

### DIFF
--- a/src/components/mdDialog/mdDialog.vue
+++ b/src/components/mdDialog/mdDialog.vue
@@ -4,7 +4,7 @@
       <slot></slot>
     </div>
 
-    <md-backdrop class="md-dialog-backdrop" :class="classes" v-if="mdBackdrop" ref="backdrop" @close="mdClickOutsideToClose && close()"></md-backdrop>
+    <md-backdrop class="md-dialog-backdrop" :class="backdropClasses" v-if="mdBackdrop" ref="backdrop" @close="mdClickOutsideToClose && close()"></md-backdrop>
   </div>
 </template>
 
@@ -27,6 +27,7 @@
         type: Boolean,
         default: true
       },
+      mdBackdropClasses: Object,
       mdOpenFrom: String,
       mdCloseTo: String,
       mdFullscreen: {
@@ -44,6 +45,9 @@
         return {
           'md-active': this.active
         };
+      },
+      backdropClasses() {
+        return Object.assign({}, this.classes, this.mdBackdropClasses);
       },
       dialogClasses() {
         return {


### PR DESCRIPTION
Today we have a "shadowed" backdrop : This is the default backdrop. 
But sometimes we need to have a fullscreen "colored" backdrop in some cases (examples of Login Dialog in Fullscreen).

Example : 

<img width="571" alt="capture d ecran 2016-12-06 a 00 00 51" src="https://cloud.githubusercontent.com/assets/5709133/20906182/25db0956-bb47-11e6-9ccf-caae9af8c7a9.png">

Demo can be found here: http://demo.geekslabs.com/materialize/v2.1/layout03/ui-buttons.html#! (menu Users/Login)

So i add the ability to add custom classes to the mdBackdrop component without touching the default class `md-backdrop`.
You can do `this.$refs.dialog.$refs.backdrop`... Not really clean. I think the better way is to send classes object directly to the dialog we need.

What do you think?
