### PR TITLE
[fix] Handling md-list-item click

### DIFF
--- a/src/components/mdList/mdListItem.vue
+++ b/src/components/mdList/mdListItem.vue
@@ -16,8 +16,8 @@
       let listItemSpec = {
         staticClass: 'md-list-item',
         on: {
-          click: () => {
-            this.$emit('click');
+          click: ($event) => {
+            this.$emit('click', $event);
           }
         }
       };


### PR DESCRIPTION
Hi,

In MdListItem, we cannot handle the @click native-event because of the declaration of the listItemSpec. 
And then, we cannot do ``@click.self`` or others because the native event is always ``undefined``, this is the vue.js code generated when we add ``@click.self`` :

```javascript
on: {
   "click": function($event) {
      if ($event.target !== $event.currentTarget) { return; }
         _vm.navigateToDetail(item)
   }
}
```

The PR just send the $event on click event in items.