### PR TITLE
fix : tablePagination bug

### DIFF
--- a/src/components/mdTable/mdTablePagination.vue
+++ b/src/components/mdTable/mdTablePagination.vue
@@ -48,7 +48,7 @@
         subTotal: 0,
         currentSize: parseInt(this.mdSize, 10),
         currentPage: parseInt(this.mdPage, 10),
-        totalItems: !isNaN(this.mdTotal) && Number.MAX_SAFE_INTEGER
+        totalItems: isNaN(this.mdTotal)?Number.MAX_SAFE_INTEGER:parseInt(this.mdTotal, 10)
       };
     },
     computed: {

--- a/src/components/mdTable/mdTablePagination.vue
+++ b/src/components/mdTable/mdTablePagination.vue
@@ -6,7 +6,7 @@
       <md-option v-for="amount in mdPageOptions" :value="amount">{{ amount }}</md-option>
     </md-select>
 
-    <span>{{ ((currentPage - 1) * currentSize) + 1 }}-{{ subTotal }} {{ mdSeparator }} {{ totalItems }}</span>
+    <span>{{ ((currentPage - 1) * currentSize) + 1 }}-{{ subTotal }} {{ mdSeparator }} {{ mdTotal }}</span>
 
     <md-button class="md-icon-button md-table-pagination-previous" @click="previousPage" :disabled="currentPage === 1">
       <md-icon>keyboard_arrow_left</md-icon>


### PR DESCRIPTION
to display the right number , not always Numer.MAX_SAFE_INTEGER or
“false”