### PR TITLE
Fix mdTheme.vue filename case

### DIFF
--- a/src/core/components/mdTheme/index.js
+++ b/src/core/components/mdTheme/index.js
@@ -1,6 +1,6 @@
 import palette from './palette';
 import rgba from './rgba';
-import MdTheme from './MdTheme';
+import MdTheme from './mdTheme';
 
 const VALID_THEME_TYPE = ['primary', 'accent', 'background', 'warn', 'hue-1', 'hue-2', 'hue-3'];
 const DEFAULT_THEME_COLORS = {


### PR DESCRIPTION
Building was failing because `src/core/components/mdTheme/index.js` was trying to import `MdTheme` instead of `mdTheme`. My guess is you're on a case-insensitive filesystem, but for us linux folk it matters :)

If you want to just do this in your own commit, that's cool.