### PR TITLE
check if .md-ripple exists (it doesn't if not using md-button)

### DIFF
--- a/src/components/mdSnackbar/mdSnackbar.vue
+++ b/src/components/mdSnackbar/mdSnackbar.vue
@@ -67,12 +67,14 @@
       }
     },
     methods: {
-      removeElement() {
-        if (this.rootElement.contains(this.snackbarElement)) {
-          this.snackbarElement.querySelector('.md-ripple').classList.remove('md-active');
-          this.rootElement.removeChild(this.snackbarElement);
-        }
-      },
+        removeElement() {
+            if (this.rootElement.contains(this.snackbarElement)) {
+                if (this.snackbarElement.querySelector('.md-ripple')) {
+                    this.snackbarElement.querySelector('.md-ripple').classList.remove('md-active');
+                }
+                this.rootElement.removeChild(this.snackbarElement);
+            }
+        },
       open() {
         if (manager.current) {
           manager.current.close();

--- a/src/components/mdSnackbar/mdSnackbar.vue
+++ b/src/components/mdSnackbar/mdSnackbar.vue
@@ -67,14 +67,17 @@
       }
     },
     methods: {
-        removeElement() {
-            if (this.rootElement.contains(this.snackbarElement)) {
-                if (this.snackbarElement.querySelector('.md-ripple')) {
-                    this.snackbarElement.querySelector('.md-ripple').classList.remove('md-active');
-                }
-                this.rootElement.removeChild(this.snackbarElement);
-            }
-        },
+      removeElement() {
+        if (this.rootElement.contains(this.snackbarElement)) {
+          const activeRipple = this.snackbarElement.querySelector('.md-ripple.md-active');
+        
+          if (activeRipple) {
+             activeRipple.classList.remove('md-active');
+          }
+          
+          this.rootElement.removeChild(this.snackbarElement);
+        }
+      },
       open() {
         if (manager.current) {
           manager.current.close();


### PR DESCRIPTION
The title pretty much says it all, but `this.snackbarElement.querySelector('.md-ripple')` is null when an `md-button` is not included causing an error in the console.