### PR TITLE
fixes md-input-container label bug #277

### DIFF
--- a/src/components/mdInputContainer/common.js
+++ b/src/components/mdInputContainer/common.js
@@ -8,6 +8,7 @@ export default {
   },
   watch: {
     value(value) {
+      this.$el.value = value;
       this.setParentValue(value);
     },
     disabled() {


### PR DESCRIPTION
It appears the watcher for `value` (in `common.js`) runs before the input's value has synced through the v-model. Thus when the watcher for `value` runs, the value provided to the function is the new value, and `this.$el.value` is still the old value.

In the case where the input value is non-`null` and you set the value to `null`, the function:

```
    setParentValue(value) {
      this.parentContainer.setValue(value || this.$el.value);
    },
```
Actually sets the parent value to the old value (since `value` is `null` and `this.$el.value` is still the old non-`null` value.) This means the parent sees the old value, it's `hasValue` is computed as true, and the `md-has-value` class is still applied, leaving the label above the input instead of in it as a placeholder.

This PR just explicitly sets `this.$el.value = value` before calling `setParentValue` in the `value` watcher, fixing the issue.

