### PR TITLE
fixes #290 - set filename even when null

### DIFF
--- a/src/components/mdFile/mdFile.vue
+++ b/src/components/mdFile/mdFile.vue
@@ -73,6 +73,8 @@
             this.filename = this.getMultipleName(files);
           } else if (files.length === 1) {
             this.filename = files[0].name;
+          } else {
+            this.filename = null;
           }
         } else {
           this.filename = $event.target.value.split('\\').pop();


### PR DESCRIPTION
This sets the v-model to null when the Cancel button is selected in the file picker to match the default browser behavior.
