### PR TITLE
Added 'change' event to mdBottomBar.

### DIFF
--- a/docs/src/pages/components/BottomBar.vue
+++ b/docs/src/pages/components/BottomBar.vue
@@ -30,6 +30,24 @@
               </md-table-row>
             </md-table-body>
           </md-table>
+
+          <md-table slot="events">
+            <md-table-header>
+              <md-table-row>
+                <md-table-head>Name</md-table-head>
+                <md-table-head>Value</md-table-head>
+                <md-table-head>Description</md-table-head>
+              </md-table-row>
+            </md-table-header>
+
+            <md-table-body>
+              <md-table-row>
+                <md-table-cell>change</md-table-cell>
+                <md-table-cell>Receive the item index</md-table-cell>
+                <md-table-cell>Triggered when an item is activated.</md-table-cell>
+              </md-table-row>
+            </md-table-body>
+          </md-table>
         </api-table>
 
         <api-table name="md-bottom-bar-item">

--- a/src/components/mdBottomBar/mdBottomBar.vue
+++ b/src/components/mdBottomBar/mdBottomBar.vue
@@ -18,6 +18,15 @@
       classes() {
         return this.mdShift ? 'md-shift' : 'md-fixed';
       }
+    },
+    methods: {
+      setActive(item) {
+        this.$children.forEach((child) => {
+          child.active = child === item;
+        });
+
+        this.$emit('change', this.$children.findIndex((i) => i === item));
+      }
     }
   };
 </script>

--- a/src/components/mdBottomBar/mdBottomBarItem.vue
+++ b/src/components/mdBottomBar/mdBottomBarItem.vue
@@ -42,11 +42,9 @@
     },
     methods: {
       setActive(active) {
-        this.$parent.$children.forEach((item) => {
-          item.active = false;
-        });
-
-        this.active = !!active;
+        if (active) {
+          this.$parent.setActive(this);
+        }
       }
     },
     mounted() {


### PR DESCRIPTION
Now we fire off an event when the active item changes, just like `mdTabs`. Additionally, this moves activation logic to `mdBottomBar`, instead of each `mdBottomBarItem`. It made the change easier to implement, and seems a bit cleaner, though that's subjective.

The primary motivation for this is to better match `mdTabs`, and to make `mdBottomBar` a bit easier to work with.
