### PR TITLE
New responsive classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/
 npm-debug.log
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .DS_Store
 node_modules/
 npm-debug.log
-dist

--- a/docs/src/pages/ui-elements/Layout.vue
+++ b/docs/src/pages/ui-elements/Layout.vue
@@ -104,6 +104,12 @@
               </md-table-row>
 
               <md-table-row>
+                <md-table-cell>md-hide-{type}-and-up</md-table-cell>
+                <md-table-cell><code>Boolean</code></md-table-cell>
+                <md-table-cell>Hide a layout container/child on screen sizes greater than or equal to given breakpoint. Example: <code>md-hide-medium-and-up</code></md-table-cell>
+              </md-table-row>
+
+              <md-table-row>
                 <md-table-cell>md-flex</md-table-cell>
                 <md-table-cell><code>Boolean|Number</code></md-table-cell>
                 <md-table-cell>Create a flexible child. If <code>true</code> the child element will grow to fill the empty space available on the parent element. If <code>Number</code> the size of the child will be sized according to the giver size. Accepts values multiple of 5. Also accepts the values 33 and 66. Default: <code>true</code></md-table-cell>

--- a/src/components/mdLayout/mdLayout.scss
+++ b/src/components/mdLayout/mdLayout.scss
@@ -175,6 +175,10 @@ $sizes: (8, 16, 24, 40);
   .md-hide-#{$size} {
     display: none;
   }
+
+  .md-hide-#{$size}-and-up {
+    display: none;
+  }
 }
 
 @include layout-xlarge {
@@ -194,5 +198,25 @@ $sizes: (8, 16, 24, 40);
 }
 
 @include layout-xsmall {
+  @include breakpoint-layout(xsmall);
+}
+
+@include layout-xlarge-and-up {
+  @include breakpoint-layout(xlarge);
+}
+
+@include layout-large-and-up {
+  @include breakpoint-layout(large);
+}
+
+@include layout-medium-and-up {
+  @include breakpoint-layout(medium);
+}
+
+@include layout-small-and-up {
+  @include breakpoint-layout(small);
+}
+
+@include layout-xsmall-and-up {
   @include breakpoint-layout(xsmall);
 }

--- a/src/components/mdLayout/mdLayout.vue
+++ b/src/components/mdLayout/mdLayout.vue
@@ -24,6 +24,11 @@
       mdHideMedium: Boolean,
       mdHideLarge: Boolean,
       mdHideXlarge: Boolean,
+      mdHideXsmallAndUp: Boolean,
+      mdHideSmallAndUp: Boolean,
+      mdHideMediumAndUp: Boolean,
+      mdHideLargeAndUp: Boolean,
+      mdHideXlargeAndUp: Boolean,
       mdGutter: [String, Number, Boolean],
       mdAlign: String,
       mdAlignXsmall: String,
@@ -63,7 +68,12 @@
           'md-hide-small': this.mdHideSmall,
           'md-hide-medium': this.mdHideMedium,
           'md-hide-large': this.mdHideLarge,
-          'md-hide-xlarge': this.mdHideXlarge
+          'md-hide-xlarge': this.mdHideXlarge,
+          'md-hide-xsmall-and-up': this.mdHideXsmallAndUp,
+          'md-hide-small-and-up': this.mdHideSmallAndUp,
+          'md-hide-medium-and-up': this.mdHideMediumAndUp,
+          'md-hide-large-and-up': this.mdHideLargeAndUp,
+          'md-hide-xlarge-and-up': this.mdHideXlargeAndUp
         };
 
         if (this.mdGutter) {

--- a/src/core/stylesheets/mixins.scss
+++ b/src/core/stylesheets/mixins.scss
@@ -51,3 +51,33 @@
     @content;
   }
 }
+
+@mixin layout-xsmall-and-up {
+  @media (min-width: #{$breakpoint-xsmall - 300px}) {
+    @content;
+  }
+}
+
+@mixin layout-small-and-up {
+  @media (min-width: #{$breakpoint-small - 300px}) {
+    @content;
+  }
+}
+
+@mixin layout-medium-and-up {
+  @media (min-width: #{$breakpoint-small - 16px}) {
+    @content;
+  }
+}
+
+@mixin layout-large-and-up {
+  @media (min-width: #{$breakpoint-medium - 16px}) {
+    @content;
+  }
+}
+
+@mixin layout-xlarge-and-up {
+  @media (min-width: #{$breakpoint-large - 16px}) {
+    @content;
+  }
+}


### PR DESCRIPTION
Currently there is no way to hide an element on a breakpoint and above, eg.: medium size and above. Given this issue, a good enhancement would be having some responsive classes. I created and I'm proposing the following classes:

```scss
md-hide-#{type}-and-up
```

Where **#{type}** can be: xsmall, small, medium, large, xlarge.

The media queries that controls those classes are:

```scss
@mixin layout-xsmall-and-up {
  @media (min-width: #{$breakpoint-xsmall - 300px}) { // 300px
    @content;
  }
}

@mixin layout-small-and-up {
  @media (min-width: #{$breakpoint-small - 300px}) { // 660px
    @content;
  }
}

@mixin layout-medium-and-up {
  @media (min-width: #{$breakpoint-small - 16px}) { //  944px
    @content;
  }
}

@mixin layout-large-and-up {
  @media (min-width: #{$breakpoint-medium - 16px}) { // 1264px
    @content;
  }
}

@mixin layout-xlarge-and-up {
  @media (min-width: #{$breakpoint-large - 16px}) { // 1904px
    @content;
  }
}
```

### Why?

Like I said before, if I want to show an element only on medium screens, right now, there is no way of doing it, based on the documentation: 

> Hide a layout container/child on screen sizes **less than** or equal to given breakpoint. 


<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/marcosmoura/vue-material/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->

I had to implement it today to show/hide a fab button. I think it will be a good asset to the project.
