### PR TITLE
Fixes for #312

### DIFF
--- a/build/webpack/prod-lib.js
+++ b/build/webpack/prod-lib.js
@@ -47,7 +47,12 @@ export default merge(baseConfig, {
     ]
   },
   externals: {
-    vue: 'Vue'
+    vue: {
+      commonjs: "vue",
+      commonjs2: "vue",
+      amd: "vue",
+      root: "Vue",
+    }
   },
   plugins: [
     new webpack.optimize.DedupePlugin(),

--- a/src/index.js
+++ b/src/index.js
@@ -74,6 +74,4 @@ options.install = (Vue) => {
   }
 };
 
-window.VueMaterial = options;
-
 export default options;


### PR DESCRIPTION
This addresses both problems (in separate commits) I bring up in issue #312:

- v0.6.2 doesn't work when just using <script> tag
- remove window.VueMaterial

You can use either or neither, just figured I would do a PR since I reported it.