### PR TITLE
Fix MdTable.vue numberOfRows bug

### DIFF
--- a/src/components/mdTable/mdTable.vue
+++ b/src/components/mdTable/mdTable.vue
@@ -55,8 +55,6 @@
       if (this.parentCard) {
         this.parentCard.tableInstance = this;
       }
-
-      window.$vm = this.data;
     }
   };
 </script>

--- a/src/components/mdTable/mdTable.vue
+++ b/src/components/mdTable/mdTable.vue
@@ -41,12 +41,22 @@
         this.$emit('select', this.selectedRows);
       }
     },
+    watch: {
+      data() {
+        this.numberOfRows = this.data.length;
+      },
+      selectedRows() {
+        this.numberOfSelected = Object.keys(this.selectedRows).length;
+      }
+    },
     mounted() {
       this.parentCard = getClosestVueParent(this.$parent, 'md-table-card');
 
       if (this.parentCard) {
         this.parentCard.tableInstance = this;
       }
+
+      window.$vm = this.data;
     }
   };
 </script>


### PR DESCRIPTION
## Bug
It happened when I removed one or more rows from the table and clicked on the "select all" checkbox. The number shown was the original data array size, not the new one (after deleting some itens). Example:

```
nutrition = [1,2,3,4,5];
numberOfRows = 5;

nutrition.splice(1,1);

nutrition = [1,3,4,5];
numberOfRows = 5; // this is the bug. it should be 4, not 5.
```

## Fix

File: mdTable.vue

```
  watch: {
    data() {
      this.numberOfRows = this.data.length;
    }
  },
```

This will guarantee the numberOfRows is always up to date.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/marcosmoura/vue-material/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->
