### PR TITLE
Fixes #327. Disable pointer events on snackbar container

### DIFF
--- a/src/components/mdSnackbar/mdSnackbar.scss
+++ b/src/components/mdSnackbar/mdSnackbar.scss
@@ -11,6 +11,7 @@ $snackbar-space: $snackbar-height / 2;
   right: 0;
   left: 0;
   z-index: 120;
+  pointer-events: none;
   transition: $swift-ease-out;
   transition-property: margin-top, margin-bottom;
 
@@ -103,6 +104,7 @@ $snackbar-space: $snackbar-height / 2;
   min-height: $snackbar-height;
   padding: $snackbar-padding 24px;
   overflow: hidden;
+  pointer-events: auto;
   border-radius: 2px;
   background-color: #323232;
   transition: $swift-ease-out;


### PR DESCRIPTION
This just disables pointer events on the invisible snackbar container so clicks can pass through.