### PR TITLE
fixes #333 allow null value to be passed to parent

### DIFF
--- a/src/components/mdSelect/mdSelect.vue
+++ b/src/components/mdSelect/mdSelect.vue
@@ -129,7 +129,7 @@
         this.selectedValue = output.value;
         this.selectedText = output.text;
 
-        if (this.selectedText && this.parentContainer) {
+        if (this.parentContainer) {
           this.parentContainer.setValue(this.selectedText);
         }
       },


### PR DESCRIPTION
This just removes the null/empty check on `this.selectedText`. If `this.selectedText` is null/empty, we want parent to know so that the label is moved down appropriately.

As far as I can tell removing this check shouldn't break anything.