### PR TITLE
Fix table arrow sort

### DIFF
--- a/src/components/mdTable/mdTableHead.vue
+++ b/src/components/mdTable/mdTableHead.vue
@@ -2,7 +2,7 @@
   <th class="md-table-head" :class="classes" @click="changeSort">
     <div class="md-table-head-container">
       <div class="md-table-head-text md-test">
-        <md-icon class="md-sortable-icon" v-if="mdSortBy">arrow_downward</md-icon>
+        <md-icon class="md-sortable-icon" v-if="mdSortBy">arrow_upward</md-icon>
 
         <slot></slot>
 


### PR DESCRIPTION
Since we are going to rotate the arrow when sort is descending:

```css
.md-table .md-sortable.md-sorted-descending .md-sortable-icon {
  transform: translateY(-50%) rotate(180deg);
}
```

The right starting arrow is `arrow_upward`.