### PR TITLE
Feature/table improvements

### DIFF
--- a/docs/src/App.vue
+++ b/docs/src/App.vue
@@ -144,6 +144,10 @@
                 </md-list-item>
 
                 <md-list-item class="md-inset">
+                  <router-link exact to="/components/table/data-table">Table (DataTable)</router-link>
+                </md-list-item>
+
+                <md-list-item class="md-inset">
                   <router-link exact to="/components/toolbar">Toolbar</router-link>
                 </md-list-item>
 

--- a/docs/src/pages/components/DataTable.vue
+++ b/docs/src/pages/components/DataTable.vue
@@ -1,0 +1,476 @@
+<template>
+  <page-content page-title="Components - DataTable">
+    <docs-component>
+      <div slot="description">
+        <p>Data tables display sets of raw data. They usually appear in desktop enterprise products. Data tables may be embedded on a surface, such as a card.</p>
+      </div>
+
+      <div slot="api">
+        <api-table name="md-data-table">
+
+          <p>This component uses md-table and others in a way that simplify use.</p>
+          <p>Data can be client-side or server-side.</p>
+
+          <md-table slot="properties">
+            <md-table-header>
+              <md-table-row>
+                <md-table-head>Name</md-table-head>
+                <md-table-head>Type</md-table-head>
+                <md-table-head>Description</md-table-head>
+              </md-table-row>
+            </md-table-header>
+
+            <md-table-body>
+              <md-table-row>
+                <md-table-cell>md-data</md-table-cell>
+                <md-table-cell><code>Array | String</code></md-table-cell>
+                <md-table-cell class="display-block">
+                  <p>Can be set with an array or a string with url to server data. This is the only <code>required</code> property.</p>
+                  <p>
+                      In case of string, an ajax request will be made (
+                      <code>page</code>, <code>pageSize</code>, <code>sortBy</code> and <code>sortType</code> parameters will be appended to the request).
+                  </p>
+                  <p>You can return data from your server in two ways:</p>
+                  <p>Body of response can contain <code>count</code> and <code>data</code> properties like example below.</p>
+                  <p>Count is the total items without pagination, and data contains only items of current page.</p>
+                  <code-block lang="javascript">
+                    {
+                      count: 10,
+                      data: [
+                        {
+                          id: 1,
+                          name: 'Chuck Norris'
+                        },
+                        {
+                          id: 2,
+                          name: 'Van Gogh'
+                        }
+                      ]
+                    }
+                  </code-block>
+                  <p>Or, if you can't return total count on response body, you can return data directly, without sub keys.</p>
+                  <p>
+                     Then you can set mdPaginationTotal property with total count, or
+                     you can leave it blank and default <code>Many</code> will appear at pagination.
+                  </p>
+                </md-table-cell>
+              </md-table-row>
+
+              <md-table-row>
+                <md-table-cell>md-fields</md-table-cell>
+                <md-table-cell><code>Array</code></md-table-cell>
+                <md-table-cell class="display-block">
+                  <p>Fields configuration, this property is not mandatory but extremely recomended.</p>
+                  <p>It sets column names, label, if it is of numeric type, if is sortable and more.</p>
+                  <p>
+                    <code>name | String </code> field name;<br />
+                    <code>label | String </code> how will be show on header;<br />
+                    <code>numeric | Boolean </code> if data type is numeric;<br />
+                    <code>sortable | Boolean </code> if can be sorted;<br />
+                    <code>icon | String </code> column header icon;<br />
+                    <code>tooltip | String </code> tooltip when mouseover column header;
+                  </p>
+                  <code-block lang="javascript">
+                    [
+                      {
+                        name: 'id',
+                        label: 'Id',
+                        numeric: true,
+                        sortable: true,
+                        icon: null,
+                        tooltip: 'ID Tooltip'
+                      },
+                      {
+                        name: 'name',
+                        label: 'Name',
+                        numeric: false,
+                        sortable: true,
+                        icon: null
+                      },
+                      {
+                        name: 'email',
+                        label: 'E-mail',
+                        numeric: false,
+                        sortable: false
+                      },
+                      {
+                        name: 'website',
+                        label: 'Website',
+                        numeric: false,
+                        sortable: true
+                      }
+                    ]
+                  </code-block>
+                </md-table-cell>
+              </md-table-row>
+
+              <md-table-row>
+                <md-table-cell>md-toolbar</md-table-cell>
+                <md-table-cell><code>Object</code></md-table-cell>
+                <md-table-cell class="display-block">
+                  <p>Configuration of toolbar.</p>
+                  <p>
+                    There're three parameters:
+                    <code>title | String</code> to set top title<br />
+                    <code>showRefreshButton | Boolean</code> to show/hide refresh button on top-right position of table.<br />
+                    <code>
+                      buttons | Array of objects</code> to add custom buttons. Each one must have two properties:
+                      <code>icon | String</code> and <code>clickEvent | Function
+                    </code>
+                  </p>
+                  <code-block lang="javascript">
+                    {
+                      title: 'Nutrition',
+                      showRefreshButton: false,
+                      buttons: [
+                        {
+                          icon: 'filter_list',
+                          clickEvent: null
+                        },
+                        {
+                          icon: 'search',
+                          clickEvent: null
+                        }
+                      ]
+                    }
+                  </code-block>
+                </md-table-cell>
+              </md-table-row>
+
+              <md-table-row>
+                <md-table-cell>md-alternate-toolbar</md-table-cell>
+                <md-table-cell><code>Object</code></md-table-cell>
+                <md-table-cell class="display-block">
+                  <p>Configuration of alternate toolbar (visible when you have rows selected).</p>
+                  <p>
+                    For now it has just one parameter:
+                    <code>
+                      buttons | Array of objects</code> to add custom buttons. Each one must have two properties:
+                      <code>icon | String</code> and <code>clickEvent | Function
+                    </code>
+                  </p>
+                  <code-block lang="javascript">
+                    {
+                      buttons: [
+                        {
+                          icon: 'filter_list',
+                          clickEvent: null
+                        },
+                        {
+                          icon: 'search',
+                          clickEvent: null
+                        }
+                      ]
+                    }
+                  </code-block>
+                </md-table-cell>
+              </md-table-row>
+
+              <md-table-row>
+                <md-table-cell>md-row-actions</md-table-cell>
+                <md-table-cell><code>Array</code></md-table-cell>
+                <md-table-cell class="display-block">
+                  <p>When set, add a button at the end of each row, for more specific actions.</p>
+                  <p>
+                    There're three parameters for each buttom:
+                    <code>icon | String</code> to set top title<br />
+                    <code>label | String</code> to show/hide refresh button on top-right position of table.<br />
+                    <code>clickEvent | Function </code> Function to be executed. Row data will be passed as param to this function.
+                  </p>
+                  <code-block lang="javascript">
+                    [
+                      {
+                        icon: 'search',
+                        label: 'Visualizar',
+                        clickEvent: null
+                      },
+                      {
+                        icon: 'edit',
+                        label: 'Editar',
+                        clickEvent: null
+                      },
+                    ]
+                  </code-block>
+                </md-table-cell>
+              </md-table-row>
+
+              <md-table-row>
+                <md-table-cell>md-row-selection</md-table-cell>
+                <md-table-cell><code>Boolean</code></md-table-cell>
+                <md-table-cell>Enable selection inside a particular row. Default <code>false</code></md-table-cell>
+              </md-table-row>
+
+              <md-table-row>
+                <md-table-cell>md-row-auto-select</md-table-cell>
+                <md-table-cell><code>Boolean</code></md-table-cell>
+                <md-table-cell>
+                  Click in any area of the row to select it.
+                  On a table with <code>md-row-actions</code> it's recomended to be turned of. Default <code>false</code>
+                </md-table-cell>
+              </md-table-row>
+
+              <md-table-row>
+                <md-table-cell>md-sort</md-table-cell>
+                <md-table-cell><code>String</code></md-table-cell>
+                <md-table-cell>Property name to match for sorting.</md-table-cell>
+              </md-table-row>
+
+              <md-table-row>
+                <md-table-cell>md-sort-type</md-table-cell>
+                <md-table-cell><code>String</code></md-table-cell>
+                <md-table-cell>The order to apply on the sort: <br>Values: <code>asc</code> | <code>desc</code></md-table-cell>
+              </md-table-row>
+
+              <md-table-row>
+                <md-table-cell>md-pagination-page</md-table-cell>
+                <md-table-cell><code>Number</code></md-table-cell>
+                <md-table-cell>Current page of the table pagination. Required. Default <code>1</code></md-table-cell>
+              </md-table-row>
+
+              <md-table-row>
+                <md-table-cell>md-pagination-size-options</md-table-cell>
+                <md-table-cell><code>Array | Boolean</code></md-table-cell>
+                <md-table-cell>Set the values inside the page amout selector. Default <code>[10, 25, 50, 100]</code> <br>When false this flag will hide the page selector.</md-table-cell>
+              </md-table-row>
+
+              <md-table-row>
+                <md-table-cell>md-pagination-rows-label</md-table-cell>
+                <md-table-cell><code>String</code></md-table-cell>
+                <md-table-cell>Text to be shown on the left of the page selector. Default <code>Rows per page</code></md-table-cell>
+              </md-table-row>
+
+              <md-table-row>
+                <md-table-cell>md-pagination-separator-label</md-table-cell>
+                <md-table-cell><code>String</code></md-table-cell>
+                <md-table-cell>Text to be shown on the left of the page selector. Default <code>of</code></md-table-cell>
+              </md-table-row>
+
+            </md-table-body>
+          </md-table>
+
+          <md-table slot="events">
+
+          </md-table>
+        </api-table>
+      </div>
+
+      <div slot="example">
+        <h2>Client</h2>
+        <md-table-card>
+          <md-data-table ref="clientdatatable"
+            :md-data="nutrition"
+            :md-row-selection="true"
+            :md-row-auto-select="true"
+            :md-toolbar="clientToolbar"
+            :md-alternate-toolbar="clientAlternateToolbar"
+          ></md-data-table>
+        </md-table-card>
+
+        <h2>Server</h2>
+        <md-table-card>
+          <md-data-table ref="serverdatatable"
+            md-data="https://api.github.com/repos/marcosmoura/vue-material/commits"
+            :md-toolbar="serverToolbar"
+            :md-fields="serverFields"
+            :md-row-actions="rowActions"
+            :md-row-selection="true"
+            :md-row-auto-select="false"
+            :md-pagination-size-options="pageSizeOptions"
+            md-pagination-rows-label="Registros"
+            md-pagination-separator-label="de"
+          ></md-data-table>
+        </md-table-card>
+      </div>
+  </page-content>
+</template>
+
+<style lang="sass" scoped>
+  .md-table + .md-table-card,
+  .md-table-card + .md-table-card {
+    margin-top: 24px;
+  }
+
+  .output {
+    margin-top: 24px;
+
+    .md-title {
+      font-size: 20px;
+    }
+  }
+</style>
+
+<style>
+  .md-table-cell.display-block .md-table-cell-container {
+    display: block !important;
+  }
+</style>
+
+<script>
+  export default {
+    data: () => ({
+      clientToolbar: {
+        title: 'Nutrition',
+        showRefreshButton: false,
+        buttons: []
+      },
+      clientAlternateToolbar: {
+        buttons: [
+          { icon: 'delete', clickEvent: null },
+          { icon: 'more_vert', clickEvent: null }
+        ]
+      },
+      serverToolbar: {
+        title: 'Users',
+        showRefreshButton: true,
+        buttons: [
+          { icon: 'search', clickEvent: null }
+        ]
+      },
+      pageSizeOptions: [5, 25, 50, 100, 500, 1000],
+      serverFields: [
+        {
+          key: 'sha',
+          label: 'Sha',
+          numeric: false,
+          sortable: true,
+          icon: 'fingerprint',
+          tooltip: 'ID Tooltip'
+        },
+        {
+          key: 'author.login',
+          label: 'Author',
+          numeric: false,
+          sortable: true,
+          icon: 'account_circle'
+        },
+        {
+          key: 'commit.message',
+          label: 'Message',
+          numeric: false,
+          sortable: true,
+          icon: 'message'
+        }
+      ],
+      rowActions: [
+        {
+          icon: 'search',
+          label: 'Visualizar',
+          clickEvent: null
+        },
+        {
+          icon: 'edit',
+          label: 'Editar',
+          clickEvent: null
+        }
+      ],
+      nutrition: [
+        {
+          dessert: 'Frozen yogurt',
+          type: 'ice_cream',
+          calories: 159,
+          fat: '6.0',
+          comment: '1'
+        },
+        {
+          dessert: 'Ice cream sandwich',
+          type: 'ice_cream',
+          calories: 237,
+          fat: '9.0',
+          comment: '2'
+        },
+        {
+          dessert: 'Eclair',
+          type: 'pastry',
+          calories: 12,
+          fat: '16.0',
+          comment: '3'
+        },
+        {
+          dessert: 'Cupcake',
+          type: 'pastry',
+          calories: 132,
+          fat: '3.7',
+          comment: '4'
+        },
+        {
+          dessert: 'Gingerbread',
+          type: 'other',
+          calories: 453,
+          fat: '16.0',
+          comment: '5'
+        },
+        {
+          dessert: 'Frozen yogurt',
+          type: 'ice_cream',
+          calories: 45,
+          fat: '6.0',
+          comment: '6'
+        },
+        {
+          dessert: 'Ice cream sandwich',
+          type: 'ice_cream',
+          calories: 987,
+          fat: '9.0',
+          comment: '7'
+        },
+        {
+          dessert: 'Eclair',
+          type: 'pastry',
+          calories: 45,
+          fat: '16.0',
+          comment: '8'
+        },
+        {
+          dessert: 'Cupcake',
+          type: 'pastry',
+          calories: 12,
+          fat: '3.7',
+          comment: '9'
+        },
+        {
+          dessert: 'Gingerbread',
+          type: 'other',
+          calories: 234,
+          fat: '16.0',
+          comment: '10'
+        },
+        {
+          dessert: 'Cupcake',
+          type: 'pastry',
+          calories: 3456,
+          fat: '3.7',
+          comment: '11'
+        },
+        {
+          dessert: 'Gingerbread',
+          type: 'other',
+          calories: 356,
+          fat: '16.0',
+          comment: '12'
+        }
+      ],
+      selectedData: [],
+      sort: {},
+      page: {}
+    }),
+    mounted() {
+      this.clientAlternateToolbar.buttons[0].clickEvent = () => {
+        this.deleteRows();
+      };
+      this.rowActions[0].clickEvent = (row) => {
+        console.log(row);
+        window.alert('Visualizar');
+      };
+      this.rowActions[1].clickEvent = (row) => {
+        console.log(row);
+        window.alert('Editar');
+      };
+    },
+    methods: {
+      deleteRows() {
+        window.alert('Delete Rows');
+        console.log(this.$refs.clientdatatable.getSelected());
+      }
+    }
+  };
+</script>

--- a/docs/src/routes.js
+++ b/docs/src/routes.js
@@ -13,6 +13,7 @@ const ButtonToggle = (resolve) => require(['./pages/components/ButtonToggle'], r
 const Card = (resolve) => require(['./pages/components/Card'], resolve);
 const Checkbox = (resolve) => require(['./pages/components/Checkbox'], resolve);
 const Chips = (resolve) => require(['./pages/components/Chips'], resolve);
+const DataTable = (resolve) => require(['./pages/components/DataTable'], resolve);
 const Dialog = (resolve) => require(['./pages/components/Dialog'], resolve);
 const File = (resolve) => require(['./pages/components/File'], resolve);
 const Icon = (resolve) => require(['./pages/components/Icon'], resolve);
@@ -107,6 +108,11 @@ const components = [
     path: '/components/chips',
     name: 'components:chips',
     component: Chips
+  },
+  {
+    path: '/components/table/data-table',
+    name: 'components:data-table',
+    component: DataTable
   },
   {
     path: '/components/dialog',

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "release": "bash build/release.sh"
   },
   "dependencies": {
-    "vue": "^2.1.8"
+    "vue": "^2.1.8",
+    "lodash": "^4.17.2"
   },
   "devDependencies": {
     "autoprefixer": "^6.6.1",

--- a/src/components/mdTable/index.js
+++ b/src/components/mdTable/index.js
@@ -7,6 +7,7 @@ import mdTableCard from './mdTableCard.vue';
 import mdTableAlternateHeader from './mdTableAlternateHeader.vue';
 import mdTablePagination from './mdTablePagination.vue';
 import mdTableTheme from './mdTable.theme';
+import mdDataTable from './mdDataTable.vue';
 
 export default function install(Vue) {
   Vue.component('md-table', Vue.extend(mdTable));
@@ -29,6 +30,7 @@ export default function install(Vue) {
   Vue.component('md-table-card', Vue.extend(mdTableCard));
   Vue.component('md-table-pagination', Vue.extend(mdTablePagination));
   Vue.component('md-table-alternate-header', Vue.extend(mdTableAlternateHeader));
+  Vue.component('md-data-table', Vue.extend(mdDataTable));
 
   Vue.material.styles.push(mdTableTheme);
 }

--- a/src/components/mdTable/mdDataTable.vue
+++ b/src/components/mdTable/mdDataTable.vue
@@ -1,0 +1,394 @@
+<template>
+  <div class="md-data-table" :class="[themeClass]">
+    <div v-show="loading" style="position:absolute; z-index:9997; width: 100%; height: 100%; min-height: 296px; text-align: center; vertical-align: middle;">
+      <div style="background: #ffffff; z-index:9998; width: 100%; height: 100%; min-height: 296px; opacity: 0.5"></div>
+      <md-spinner :md-size="150" :md-stroke="1" md-indeterminate class="md-warn" style="position:absolute; top:50%; height:10em; margin-top:-70px; margin-left: -75px;"></md-spinner>
+    </div>
+
+    <md-toolbar v-show="showToolbar">
+      <h1 class="md-title">{{ toolbar.title }}</h1>
+      <md-button v-for="(button, buttonIndex) in toolbarButtons" class="md-icon-button" @click.prevent="button.clickEvent">
+        <md-icon>{{ button.icon }}</md-icon>
+      </md-button>
+      <md-button v-show="typeof toolbar.showRefreshButton !== 'undefined' && toolbar.showRefreshButton === true" class="md-icon-button" @click.prevent="refresh()">
+        <md-icon>refresh</md-icon>
+      </md-button>
+    </md-toolbar>
+
+    <md-table-alternate-header md-selected-label="selected" v-show="showAlternateToolbar">
+      <md-button v-for="(button, buttonIndex) in mdAlternateToolbar.buttons" class="md-icon-button" @click.prevent="button.clickEvent">
+        <md-icon>{{ button.icon }}</md-icon>
+      </md-button>
+    </md-table-alternate-header>
+
+    <md-table :md-sort="sortBy" :md-sort-type="sortType" @select="onSelect" @sort="onSort" v-show="!loading">
+      <md-table-header>
+        <md-table-row>
+          <md-table-head v-for="(column, columnIndex) in fields" :md-sort-by="column.sortable ? column.key : ''" :md-numeric="column.numeric" :md-tooltip="column.tooltip">
+            <md-icon v-if="column.icon !== null">{{ column.icon }}</md-icon>
+            {{ typeof column.label !== 'undefined' && column.label !== null ? column.label : column.key }}
+          </md-table-head>
+        </md-table-row>
+      </md-table-header>
+
+      <md-table-body>
+        <md-table-row v-for="(row, rowIndex) in visibleRows" :key="rowIndex" :md-item="row" :md-selection="mdRowSelection" :md-auto-select="mdRowAutoSelect">
+          <md-table-cell v-for="(column, columnIndex) in row" :key="columnIndex" :md-numeric="fieldsNumericKeys.indexOf(columnIndex) !== -1">
+            {{ column }}
+          </md-table-cell>
+
+          <md-table-cell v-if="mdRowActions.length > 0">
+            <md-menu md-size="3">
+              <md-button class="md-icon-button" md-menu-trigger>
+                <md-icon>more_vert</md-icon>
+              </md-button>
+
+              <md-menu-content>
+                <md-menu-item v-for="(button, buttonIndex) in mdRowActions" @click="button.clickEvent(row)">
+                  <md-icon>{{ button.icon }}</md-icon>
+                  <span>{{ button.label }}</span>
+                </md-menu-item>
+              </md-menu-content>
+            </md-menu>
+          </md-table-cell>
+        </md-table-row>
+      </md-table-body>
+    </md-table>
+    <md-table-pagination ref="pagination" v-show="!loading"
+      :md-total="dataCount"
+      :md-page="page"
+      :md-size="pageSize"
+      :md-page-options="pageSizeOptions"
+      :md-label="mdPaginationRowsLabel"
+      :md-separator="mdPaginationSeparatorLabel"
+    @pagination="onPagination"></md-table-pagination>
+  </div>
+</template>
+
+<script>
+  import Vue from 'vue';
+  import theme from '../../core/components/mdTheme/mixin';
+  import getClosestVueParent from '../../core/utils/getClosestVueParent';
+  import { getData, getServerRequestParameters } from '../../core/utils/getData';
+  import { get, sortBy } from 'lodash';
+
+  export default {
+    props: {
+      mdHttp: {
+        type: Function,
+        default() {
+          return null;
+        }
+      },
+      mdHttpHeaders: {
+        type: Object,
+        default() {
+          return {};
+        }
+      },
+      mdData: {
+        type: Array | String,
+        required: true,
+        default() {
+          return [];
+        }
+      },
+      mdToolbar: {
+        type: Object,
+        default() {
+          return {
+            title: '',
+            showRefreshButton: false,
+            buttons: []
+          };
+        }
+      },
+      mdAlternateToolbar: {
+        type: Object,
+        default() {
+          return {
+            buttons: []
+          };
+        }
+      },
+      mdFields: {
+        type: Array,
+        default() {
+          return [];
+        }
+      },
+      mdRowActions: {
+        type: Array,
+        default() {
+          return [];
+        }
+      },
+      mdRowSelection: {
+        type: Boolean,
+        default() {
+          return false;
+        }
+      },
+      mdRowAutoSelect: {
+        type: Boolean,
+        default() {
+          return false;
+        }
+      },
+      mdSort: {
+        type: String,
+        default() {
+          return 'name';
+        }
+      },
+      mdSortType: {
+        type: String,
+        default() {
+          return 'asc';
+        }
+      },
+      mdPaginationTotal: {
+        type: Number | String,
+        default() {
+          return 'Many';
+        }
+      },
+      mdPaginationPage: {
+        type: Number,
+        default() {
+          return 1;
+        }
+      },
+      mdPaginationSizeOptions: {
+        type: Array,
+        default() {
+          return [5, 10, 25, 50];
+        }
+      },
+      mdPaginationSize: {
+        type: Number,
+        default() {
+          return this.mdPaginationSizeOptions[0];
+        }
+      },
+      mdPaginationRowsLabel: {
+        type: String,
+        default() {
+          return 'Rows';
+        }
+      },
+      mdPaginationSeparatorLabel: {
+        type: String,
+        default() {
+          return 'of';
+        }
+      }
+    },
+    mixins: [theme],
+    data() {
+      return {
+        loading: false,
+        toolbar: this.mdToolbar,
+        toolbarButtons: [],
+        alternateToolbar: this.mdAlternateToolbar,
+        alternateToolbarButtons: [],
+        data: {},
+        dataCount: this.mdPaginationTotal,
+        page: this.mdPaginationPage,
+        pageSize: this.mdPaginationSize,
+        pageSizeOptions: this.mdPaginationSizeOptions,
+        sortBy: this.mdSort,
+        sortType: this.mdSortType,
+        fields: [],
+        fieldsKeys: [],
+        fieldsNumericKeys: [],
+        visibleRows: [],
+        serverSidePagination: false,
+        numberOfRows: 0,
+        numberOfSelected: 0,
+        selectedRows: {}
+      };
+    },
+    computed: {
+      serverSide() {
+        return typeof this.mdData === 'string';
+      },
+      showToolbar() {
+        return this.toolbar !== 'undefined' && Object.keys(this.toolbar).length > 0;
+      },
+      showAlternateToolbar() {
+        return typeof this.alternateToolbar !== 'undefined' && Object.keys(this.alternateToolbar.buttons).length > 0;
+      }
+    },
+    created() {
+      this.$watch('data', this.onDataChange, {
+        immediate: true
+      });
+
+      this.bootstrap();
+    },
+    methods: {
+      bootstrap() {
+        if (this.showToolbar && typeof this.toolbar.buttons !== 'undefined') {
+          this.addToolbarButtons();
+        }
+
+        this.parentCard = getClosestVueParent(this.$parent, 'md-table-card');
+
+        if (this.parentCard) {
+          this.parentCard.tableInstance = this;
+        }
+
+        if (this.serverSide) {
+          this.getServerData(true);
+        } else {
+          this.dataCount = this.mdData.length;
+          this.$set(this, 'data', this.mdData);
+        }
+      },
+      onDataChange(value) {
+        this.setFields(value);
+        this.render();
+      },
+      setFields(data = []) {
+        if (Object.keys(this.mdFields).length > 0) {
+          this.fields = this.mdFields;
+        } else if (data.length > 0) {
+          let fields = [];
+          let fieldsArray = Object.getOwnPropertyNames(data[0]);
+          let obIndex = fieldsArray.indexOf('__ob__');
+
+          if (obIndex > -1) {
+            fieldsArray.splice(obIndex, 1);
+          }
+
+          fieldsArray.map((item) => {
+            fields.push({
+              key: item,
+              label: `${item.charAt(0).toUpperCase()}${item.slice(1)}`,
+              numeric: false,
+              sortable: true,
+              icon: null
+            });
+          });
+
+          this.fields = fields;
+        } else {
+          this.fields = [];
+        }
+
+        this.setFieldsKeys();
+        this.setFieldsNumericKeys();
+      },
+      setFieldsKeys() {
+        let fieldsKeys = [];
+
+        this.fields.map((row) => {
+          fieldsKeys.push(row.key);
+        });
+
+        this.fieldsKeys = fieldsKeys;
+      },
+      setFieldsNumericKeys() {
+        this.fieldsNumericKeys = this.fields.filter((value) => {
+          return value.numeric === true;
+        }).map(function(a) {
+          return a.name;
+        });
+      },
+      addToolbarButtons() {
+        let buttons = [];
+
+        this.toolbar.buttons.map((item) => {
+          buttons.push(item);
+        });
+
+        this.toolbarButtons = buttons;
+      },
+      getServerData() {
+        this.loading = true;
+        const http = Vue.$http || this.mdHttp;
+        const url = `${this.mdData}?${getServerRequestParameters(this.page, this.pageSize, this.sortBy, this.sortType)}`;
+
+        getData(url, http, this.mdHttpHeaders).then((data) => {
+          this.prepareServerData(data);
+        });
+      },
+      prepareServerData(responseBody) {
+        if (typeof responseBody.count !== 'undefined' && typeof responseBody.data !== 'undefined') {
+          this.serverSidePagination = true;
+          this.dataCount = responseBody.count;
+          this.$set(this, 'data', responseBody.data);
+        } else {
+          this.serverSidePagination = false;
+          this.dataCount = this.mdPaginationTotal === null || isNaN(this.mdPaginationTotal) ? 'Many' : this.mdPaginationTotal;
+          this.$set(this, 'data', this.dataFieldsFilter(responseBody));
+        }
+
+        this.render();
+        this.loading = false;
+      },
+      dataFieldsFilter(data) {
+        let row = {};
+        let rows = [];
+
+        data.map((r) => {
+          row = {};
+
+          this.fieldsKeys.map((k) => {
+            row[k] = get(r, k);
+          });
+
+          rows.push(row);
+        });
+
+        return rows;
+      },
+      onSelect(data) {
+        this.selectedData = data;
+      },
+      onSort(sort) {
+        this.sortBy = sort.name;
+        this.sortType = sort.type;
+
+        this.refresh();
+      },
+      onPagination(pagination) {
+        if (pagination.size !== this.pageSize) {
+          this.page = 1;
+          this.pageSize = pagination.size;
+        } else {
+          this.page = pagination.page;
+        }
+
+        this.refresh();
+      },
+      refresh() {
+        if (this.serverSide) {
+          this.getServerData();
+        } else {
+          this.render();
+        }
+      },
+      render() {
+        if (this.serverSidePagination) {
+          this.visibleRows = this.data;
+          return;
+        }
+
+        let offset = (this.page - 1) * this.pageSize;
+        let orderedData = sortBy(this.data, this.sortBy);
+
+        if (this.sortType === 'desc') {
+          orderedData.reverse();
+        }
+
+        this.visibleRows = orderedData.slice(offset, offset + this.pageSize);
+        this.page = 1;
+      },
+      getSelected() {
+        return this.selectedData;
+      }
+    }
+  };
+</script>

--- a/src/components/mdTable/mdTablePagination.vue
+++ b/src/components/mdTable/mdTablePagination.vue
@@ -6,7 +6,7 @@
       <md-option v-for="amount in mdPageOptions" :value="amount">{{ amount }}</md-option>
     </md-select>
 
-    <span>{{ ((currentPage - 1) * currentSize) + 1 }}-{{ subTotal }} {{ mdSeparator }} {{ mdTotal }}</span>
+    <span>{{ currentRange }} {{ mdSeparator }} {{ mdTotal }}</span>
 
     <md-button class="md-icon-button md-table-pagination-previous" @click="previousPage" :disabled="currentPage === 1">
       <md-icon>keyboard_arrow_left</md-icon>
@@ -47,13 +47,18 @@
       return {
         subTotal: 0,
         currentSize: parseInt(this.mdSize, 10),
-        currentPage: parseInt(this.mdPage, 10),
-        totalItems: isNaN(this.mdTotal) ? Number.MAX_SAFE_INTEGER : parseInt(this.mdTotal, 10)
+        currentPage: parseInt(this.mdPage, 10)
       };
     },
     computed: {
       lastPage() {
         return false;
+      },
+      totalItems() {
+        return isNaN(this.mdTotal) ? Number.MAX_SAFE_INTEGER : parseInt(this.mdTotal, 10);
+      },
+      currentRange() {
+        return `${(this.currentPage - 1) * this.currentSize + 1}-${this.subTotal}`;
       }
     },
     methods: {

--- a/src/core/utils/getData.js
+++ b/src/core/utils/getData.js
@@ -1,0 +1,65 @@
+const getServerRequestParameters = (page, pageSize, sortBy, sortType) => {
+  const params = {
+    page: page,
+    pageSize: pageSize,
+    per_page: pageSize,
+    sortBy: sortBy,
+    sortType: sortType
+  };
+
+  return Object.keys(params).map(function(key) {
+    return `${key}=${encodeURIComponent(params[key])}`;
+  }).join('&');
+};
+
+const getResponseData = (response) => {
+  if (typeof response.body === 'undefined') {
+    return response;
+  }
+
+  return response.body;
+};
+
+const getData = (data, http = null, httpHeaders = {}) => {
+  return new Promise((resolve, reject) => {
+    if (typeof data !== 'string') {
+      resolve(data);
+      return;
+    }
+
+    if (http !== null && typeof http.get !== 'undefined') {
+      http.get(data).then((response) => {
+        resolve(getResponseData(response));
+      }, { headers: httpHeaders })
+      .catch(function(reason) {
+        reject(new Error(reason));
+      });
+
+      return;
+    }
+
+    var request = new XMLHttpRequest();
+
+    request.onreadystatechange = function() {
+      if (this.readyState === 4 && this.status === 200) {
+        resolve(JSON.parse(getResponseData(this.response)));
+      } else if (this.readyState === 4) {
+        reject(new Error(this.statusText));
+      }
+    };
+
+    request.onerror = function() {
+      reject(new Error(`XMLHttpRequest Error: ${this.statusText}`));
+    };
+
+    request.open('GET', data);
+
+    Object.entries(httpHeaders).forEach(([key, value]) => {
+      request.setRequestHeader(key, value);
+    });
+
+    request.send();
+  });
+};
+
+export { getData, getServerRequestParameters };


### PR DESCRIPTION
Hi,

  At our company we decided to use Vue Material as frontend framework. Our actual basic needs was attended except by two components: a data table, more read-to-use and configurable, and a select component with server-side option, like select2 (next development).

  So we build a <md-data-table> component, that uses mdTable and others, but add some functionalities and facilities. Now we can fetch data from client or server, with local or remote pagination and more.

  I think it can be helpfull to others, so I'm submiting this pull request, what do you think? Is something to be on Vue Material core?


Regards!