### PR TITLE
Allow preventDefault in md-switch

### DIFF
--- a/src/components/mdSwitch/mdSwitch.vue
+++ b/src/components/mdSwitch/mdSwitch.vue
@@ -66,9 +66,22 @@
         this.leftPos = this.checked ? checkedPosition + '%' : initialPosition;
       },
       changeState(checked, $event) {
-        this.checked = checked;
-        this.$emit('change', this.checked, $event);
-        this.$emit('input', this.checked, $event);
+        if ($event !== undefined) {
+          // $event is not undefined when changeState called from toggle (user click)
+          this.$emit('change', $event); //call emit so user's code will receive onchange
+          // first argument passed as $event variable in onchange context
+
+          if (!$event.defaultPrevented) {
+            // in handler user may prevent default by calling $event.preventDefault so we
+            // don't need to do actual change state in this case
+            this.checked = checked;
+          }
+          this.$emit('input', this.checked, $event);
+        } else {
+          // $event is undefined when changeState called from value watch
+          // in this case we only need to update the state
+          this.checked = checked;
+        }
       },
       toggle($event) {
         if (!this.disabled) {

--- a/src/components/mdSwitch/mdSwitch.vue
+++ b/src/components/mdSwitch/mdSwitch.vue
@@ -66,20 +66,14 @@
         this.leftPos = this.checked ? checkedPosition + '%' : initialPosition;
       },
       changeState(checked, $event) {
-        if ($event !== undefined) {
-          // $event is not undefined when changeState called from toggle (user click)
-          this.$emit('change', $event); //call emit so user's code will receive onchange
-          // first argument passed as $event variable in onchange context
+        if (typeof $event !== 'undefined') {
+          this.$emit('change', $event);
 
           if (!$event.defaultPrevented) {
-            // in handler user may prevent default by calling $event.preventDefault so we
-            // don't need to do actual change state in this case
             this.checked = checked;
           }
           this.$emit('input', this.checked, $event);
         } else {
-          // $event is undefined when changeState called from value watch
-          // in this case we only need to update the state
           this.checked = checked;
         }
       },


### PR DESCRIPTION
This allows call `$event.preventDefault()` from `<md-switch @change=''`. It is usefull if we want to prevent changing of switch state to confirm change in dialog. Also issue related to this https://github.com/marcosmoura/vue-material/issues/433
Possible use:
```html
<md-switch  @change="$event.preventDefault();start_confirm_dialog()">
```
Or same in `Vue` style:
```html
<md-switch  @change.prevent="start_confirm_dialog()">
```
Also it allows `$event.stopPropagation()` or `@change.stop` which is usefull if md-swith is placed on expanded list and if developer wants to prevent expanding of list when user his on switch.
Solution explained in comments. Thanks

