### PR TITLE
[md-select] Doc for @opened and @closed

### DIFF
--- a/docs/src/pages/components/Select.vue
+++ b/docs/src/pages/components/Select.vue
@@ -76,6 +76,16 @@
                 <md-table-cell>Receives the value of the model</md-table-cell>
                 <md-table-cell>Triggered when the model changes.</md-table-cell>
               </md-table-row>
+              <md-table-row>
+                <md-table-cell>opened</md-table-cell>
+                <md-table-cell>None</md-table-cell>
+                <md-table-cell>Triggered when the select menu starts to open.</md-table-cell>
+              </md-table-row>
+              <md-table-row>
+                <md-table-cell>closed</md-table-cell>
+                <md-table-cell>None</md-table-cell>
+                <md-table-cell>Triggered when the select menu starts to close.</md-table-cell>
+              </md-table-row>
             </md-table-body>
           </md-table>
         </api-table>


### PR DESCRIPTION
I wanted to create the @opened/@closed event in mdSelect component but I saw that you already have made this improvement in the dev branch. So I just pull the doc update instead (same description as mdMenu)...