### PR TITLE
Option that allow multiple items be expanded in same time in md-list

### DIFF
--- a/docs/src/pages/components/List.vue
+++ b/docs/src/pages/components/List.vue
@@ -38,6 +38,24 @@
               </md-table-row>
             </md-table-body>
           </md-table>
+
+          <md-table slot="properties">
+            <md-table-header>
+              <md-table-row>
+                <md-table-head>Name</md-table-head>
+                <md-table-head>Type</md-table-head>
+                <md-table-head>Description</md-table-head>
+              </md-table-row>
+            </md-table-header>
+
+            <md-table-body>
+              <md-table-row>
+                <md-table-cell>allow-multiple-expanded</md-table-cell>
+                <md-table-cell><code>Boolean</code></md-table-cell>
+                <md-table-cell>Allow multiple items be expanded in same time (for lists with expansion items).</md-table-cell>
+              </md-table-row>
+            </md-table-body>
+          </md-table>
         </api-table>
 
         <api-table name="md-list-item">

--- a/src/components/mdList/mdList.vue
+++ b/src/components/mdList/mdList.vue
@@ -10,6 +10,12 @@
   import theme from '../../core/components/mdTheme/mixin';
 
   export default {
-    mixins: [theme]
+    mixins: [theme],
+    props: {
+      allowMultipleExpanded: {
+        type: Boolean,
+        default: false
+      }
+    }
   };
 </script>

--- a/src/components/mdList/mdListItem.vue
+++ b/src/components/mdList/mdListItem.vue
@@ -65,15 +65,19 @@
         let target;
 
         scope.$parent.$children.some((child) => {
-          var classList = child.$el.classList;
+          // if vue-material user wants to allow several items expanded without closing already expanded item
+          // allowMultipleExpanded will be true, so not fold all items, fold only that one which clicked
+          if (scope.$el === child.$el || !scope.$parent.allowMultipleExpanded) {
+            var classList = child.$el.classList;
 
-          if (classList.contains('md-list-item-expand') && classList.contains('md-active')) {
-            target = child;
-            classList.remove('md-active');
+            if (classList.contains('md-list-item-expand') && classList.contains('md-active')) {
+              target = child;
+              classList.remove('md-active');
 
-            recalculateExpand(child);
+              recalculateExpand(child);
 
-            return true;
+              return true;
+            }
           }
         });
 


### PR DESCRIPTION
Option `allow-multiple-expanded` that allow multiple expanded items in `<md-list>`. Default value is `false` so it will not brake any backward compatibility.
* Behavior when `allow-multiple-expanded` or not specified (works as it was before): if some item already expanded, expanding new will fold already expanded 
* When `allow-multiple-expanded` is used (`<md-list allow-multiple-expanded>` ): if some item already expanded, expanding new will not fold already expanded, but click on expanded item still will fold it.