### PR TITLE
Scroll the selected md-menu into view when the md-select is opened.

### DIFF
--- a/src/components/mdSelect/mdSelect.vue
+++ b/src/components/mdSelect/mdSelect.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="md-select" :class="[themeClass, classes]">
-    <md-menu :md-close-on-select="!multiple" @opened="$emit('open')" @closed="$emit('close')">
+    <md-menu :md-close-on-select="!multiple" @open="onOpen" @opened="$emit('open')" @closed="$emit('close')">
       <span class="md-select-value" md-menu-trigger ref="value">{{ selectedText || placeholder }}</span>
 
       <md-menu-content class="md-select-content" :class="[themeClass, contentClasses]">
@@ -72,6 +72,17 @@
       }
     },
     methods: {
+      onOpen() {
+        Object.filter = (obj, predicate) =>
+          Object.keys(obj)
+            .filter((key) => predicate(obj[key]))
+            .map((key) => {
+              return obj[key];
+            });
+
+        var filtered = Object.filter(this.options, (option) => option.isSelected);  
+        filtered[0].$el.scrollIntoView(true);
+      },
       setParentDisabled() {
         this.parentContainer.isDisabled = this.disabled;
       },


### PR DESCRIPTION
This is my stab at a large list of items in the md-select when the user selects a option towards the end of the list and reopens the list it should automatically scroll to the selected item.

For example when a user selects the Verdana font and reopens the md-select it should show that selection.

![image](https://cloud.githubusercontent.com/assets/4716711/22776381/19b065a0-eeb8-11e6-9633-f31448f71b28.png)
