### PR TITLE
Fix problem with german keyboards.

### DIFF
--- a/src/components/mdChips/mdChips.vue
+++ b/src/components/mdChips/mdChips.vue
@@ -19,7 +19,6 @@
         :disabled="disabled"
         @keydown.native.delete="deleteLastChip"
         @keydown.native.prevent.enter="addChip"
-        @keydown.native.prevent.186="addChip"
         tabindex="0"
         ref="input">
       </md-input>


### PR DESCRIPTION
The key 186 is the 'ö' key on german keyboards. I'm sure it means many other things on many other keyboard. So this line would break the component for many people and should be removed.