### PR TITLE
watchable sort parameters in md-table

### DIFF
--- a/docs/src/pages/components/Table.vue
+++ b/docs/src/pages/components/Table.vue
@@ -337,7 +337,7 @@
                 </md-button>
               </md-toolbar>
 
-              <md-table md-sort="dessert" md-sort-type="desc" @select="onSelect" @sort="onSort">
+              <md-table :md-sort="sortInput.name" :md-sort-type="sortInput.type" @select="onSelect" @sort="onSort">
                 <md-table-header>
                   <md-table-row>
                     <md-table-head md-sort-by="dessert">Dessert (100g serving)</md-table-head>
@@ -372,6 +372,27 @@
             <div class="output">
               <h2 class="md-title">Selected Data</h2>
               <pre>{{ selectedData }}</pre>
+            </div>
+
+            <div class="output">
+              <h2 class="md-title">Sort input</h2>
+              <md-input-container>
+                <label for="sort-input-name">Name</label>
+                <md-select name="sort-input-name" id="sort-input-name" v-model="sortInput.name">
+                  <md-option value="">None</md-option>
+                  <md-option value="dessert">Dessert</md-option>
+                  <md-option value="calories">Calories</md-option>
+                  <md-option value="fat">Fat</md-option>
+                </md-select>
+              </md-input-container>
+
+              <md-input-container>
+                <label for="sort-input-type">Type</label>
+                <md-select name="sort-input-type" id="sort-input-type" v-model="sortInput.type">
+                  <md-option value="asc">Ascending</md-option>
+                  <md-option value="desc">Descending</md-option>
+                </md-select>
+              </md-input-container>
             </div>
 
             <div class="output">
@@ -716,6 +737,10 @@
         }
       ],
       selectedData: [],
+      sortInput: {
+        name: 'dessert',
+        type: 'asc'
+      },
       sort: {},
       page: {}
     }),

--- a/src/components/mdTable/mdTable.vue
+++ b/src/components/mdTable/mdTable.vue
@@ -47,6 +47,14 @@
       },
       selectedRows() {
         this.numberOfSelected = Object.keys(this.selectedRows).length;
+      },
+      mdSort() {
+        this.sortBy = this.mdSort;
+        this.$emit('sortInput');
+      },
+      mdSortType() {
+        this.sortType = this.mdSortType;
+        this.$emit('sortInput');
       }
     },
     mounted() {

--- a/src/components/mdTable/mdTableHead.vue
+++ b/src/components/mdTable/mdTableHead.vue
@@ -63,15 +63,20 @@
           this.parentTable.sortType = this.sortType;
           this.parentTable.emitSort(this.mdSortBy);
         }
+      },
+      initSort() {
+        if (this.hasMatchSort()) {
+          this.sorted = true;
+          this.sortType = this.parentTable.sortType;
+        }
       }
     },
     mounted() {
       this.parentTable = getClosestVueParent(this.$parent, 'md-table');
-
-      if (this.hasMatchSort()) {
-        this.sorted = true;
-        this.sortType = this.parentTable.sortType;
-      }
+      this.initSort();
+      this.parentTable.$on('sortInput', () => {
+        this.initSort();
+      });
     }
   };
 </script>


### PR DESCRIPTION
Hello,

I realize I did not submit a request for this. But I was in a hurry to get the functionality, and I was happy to dive a little bit in your code.

The purpose of this PR is to manage sorting parameters from outside the table. The use case is for very dynamic tables where the columns, filters, etc are modified by the parent. Re-initializing sort parameters is useful in this context.