### PR TITLE
Fix for issue with md-table-pagination component not enabling the paging buttons when total items is updated, after component is rendered

### DIFF
--- a/src/components/mdTable/mdTablePagination.vue
+++ b/src/components/mdTable/mdTablePagination.vue
@@ -12,7 +12,7 @@
       <md-icon>keyboard_arrow_left</md-icon>
     </md-button>
 
-    <md-button class="md-icon-button md-table-pagination-next" @click.native="nextPage" :disabled="currentSize * currentPage >= totalItems">
+    <md-button class="md-icon-button md-table-pagination-next" @click.native="nextPage" :disabled="hasMoreItems">
       <md-icon>keyboard_arrow_right</md-icon>
     </md-button>
   </div>
@@ -46,14 +46,28 @@
     data() {
       return {
         subTotal: 0,
-        currentSize: parseInt(this.mdSize, 10),
-        currentPage: parseInt(this.mdPage, 10),
-        totalItems: isNaN(this.mdTotal) ? Number.MAX_SAFE_INTEGER : parseInt(this.mdTotal, 10)
+        totalItems: 0,
+        currentPage: 1,
+        currentSize: 0
       };
+    },
+    watch: {
+      mdTotal(val) {
+        this.totalItems = isNaN(val) ? Number.MAX_SAFE_INTEGER : parseInt(val, 10);
+      },
+      mdSize(val) {
+        this.currentSize = parseInt(this.mdSize, 10);
+      },
+      mdPage(val) {
+        this.currentPage = parseInt(this.mdPage, 10);
+      }
     },
     computed: {
       lastPage() {
         return false;
+      },
+      hasMoreItems() {
+        return this.currentSize * this.currentPage >= this.totalItems;
       }
     },
     methods: {


### PR DESCRIPTION
- Added watchers on mdTotal and mdPage. 
- Changed the binding for the disabled attribute of the next page arrow to use a computed property.

This PR is for the bug described in #482.