### PR TITLE
fixed bug where mdMenuContent was preventing space key on mdInput

### DIFF
--- a/src/components/mdMenu/mdMenuContent.vue
+++ b/src/components/mdMenu/mdMenuContent.vue
@@ -5,8 +5,8 @@
     @keydown.tab.prevent="close"
     @keydown.up.prevent="highlightItem('up')"
     @keydown.down.prevent="highlightItem('down')"
-    @keydown.enter.prevent="fireClick"
-    @keydown.space.prevent="fireClick"
+    @keydown.enter="fireClick"
+    @keydown.space="fireClick"
     tabindex="-1">
     <md-list>
       <slot></slot>


### PR DESCRIPTION
[bug](http://codepen.io/struwigcd/pen/PWydOK)

issue #478 

``` vue
<div
  class="md-menu-content"
  @keydown.esc.prevent="close"
  @keydown.tab.prevent="close"
  @keydown.up.prevent="highlightItem('up')"
  @keydown.down.prevent="highlightItem('down')"
  @keydown.enter.prevent="fireClick"
  @keydown.space.prevent="fireClick"
  tabindex="-1">
  <md-list>
    <slot></slot>
  </md-list>
</div>
```

**.prevent** on **@keydown.space.prevent** and **@keydown.enter.prevent** seems to be unnecessary and was preventing the space key on mdInput inside mdMenuContent