### PR TITLE
Follow-up for #517

### DIFF
--- a/src/components/mdTable/mdTablePagination.vue
+++ b/src/components/mdTable/mdTablePagination.vue
@@ -12,7 +12,7 @@
       <md-icon>keyboard_arrow_left</md-icon>
     </md-button>
 
-    <md-button class="md-icon-button md-table-pagination-next" @click.native="nextPage" :disabled="hasMoreItems">
+    <md-button class="md-icon-button md-table-pagination-next" @click.native="nextPage" :disabled="shouldDisable">
       <md-icon>keyboard_arrow_right</md-icon>
     </md-button>
   </div>
@@ -56,17 +56,17 @@
         this.totalItems = isNaN(val) ? Number.MAX_SAFE_INTEGER : parseInt(val, 10);
       },
       mdSize(val) {
-        this.currentSize = parseInt(this.mdSize, 10);
+        this.currentSize = parseInt(val, 10);
       },
       mdPage(val) {
-        this.currentPage = parseInt(this.mdPage, 10);
+        this.currentPage = parseInt(val, 10);
       }
     },
     computed: {
       lastPage() {
         return false;
       },
-      hasMoreItems() {
+      shouldDisable() {
         return this.currentSize * this.currentPage >= this.totalItems;
       }
     },

--- a/src/components/mdTable/mdTablePagination.vue
+++ b/src/components/mdTable/mdTablePagination.vue
@@ -12,7 +12,7 @@
       <md-icon>keyboard_arrow_left</md-icon>
     </md-button>
 
-    <md-button class="md-icon-button md-table-pagination-next" @click.native="nextPage" :disabled="currentSize * currentPage >= totalItems">
+    <md-button class="md-icon-button md-table-pagination-next" @click.native="nextPage" :disabled="hasMoreItems">
       <md-icon>keyboard_arrow_right</md-icon>
     </md-button>
   </div>
@@ -46,14 +46,28 @@
     data() {
       return {
         subTotal: 0,
-        currentSize: parseInt(this.mdSize, 10),
-        currentPage: parseInt(this.mdPage, 10),
-        totalItems: isNaN(this.mdTotal) ? Number.MAX_SAFE_INTEGER : parseInt(this.mdTotal, 10)
+        totalItems: 0,
+        currentPage: 1,
+        currentSize: 0
       };
+    },
+    watch: {
+      mdTotal(val) {
+        this.totalItems = isNaN(val) ? Number.MAX_SAFE_INTEGER : parseInt(val, 10);
+      },
+      mdSize(val) {
+        this.currentSize = parseInt(this.mdSize, 10);
+      },
+      mdPage(val) {
+        this.currentPage = parseInt(this.mdPage, 10);
+      }
     },
     computed: {
       lastPage() {
         return false;
+      },
+      hasMoreItems() {
+        return this.currentSize * this.currentPage >= this.totalItems;
       }
     },
     methods: {


### PR DESCRIPTION
@marcosmoura this is a follow-up of PR #517 to change the name of the computed property for disabling the next-page button; this is to make the code a bit more clear and easy to read. 

I have also changed the `watch` handlers to use the value passed to them instead of referencing the values from the component instance for `mdSize` and `mdPage`.

P.S: I merged your master branch to my fork before raising this PR.