### PR TITLE
Added registerPalette method on mdTheme

### DIFF
--- a/src/core/components/mdTheme/index.js
+++ b/src/core/components/mdTheme/index.js
@@ -144,6 +144,9 @@ export default function install(Vue) {
       inkRipple: true
     }),
     methods: {
+      registerPalette(name, spec) {
+        palette[name] = spec;
+      },
       registerTheme(name, spec) {
         let theme = {};
 


### PR DESCRIPTION
Adding a new method `Vue.material.registerPalette` as seen on issue #202 

> https://github.com/marcosmoura/vue-material/issues/202#issuecomment-279143110
> ```js 
> Vue.material.registerPalette( 'my-palette', {
>   50: '#f3e0e0',
>   100: '#e0b3b3',
>   200: '#cc8080',
>   300: '#b84d4d',
>   400: '#a82626',
>   500: '#990000',
>   600: '#910000',
>   700: '#860000',
>   800: '#7c0000',
>   900: '#6b0000',
>   A100: '#ff9a9a',
>   A200: '#ff6767',
>   A400: '#ff3434',
>   A700: '#ff1a1a',
>   darkText: [ 50, 100, 'A100', 'A200' ]
> });
> Vue.material.registerTheme( 'default', { primary: 'my-palette' } );
> ```