### PR TITLE
Fix #534 centering icon with md-button in md-table

### DIFF
--- a/src/components/mdTable/mdTable.scss
+++ b/src/components/mdTable/mdTable.scss
@@ -187,7 +187,6 @@
         min-width: $size;
         height: $size;
         min-height: $size;
-        margin: 0;
         color: rgba(#000, .54);
         font-size: $size;
       }


### PR DESCRIPTION
This fixes #534, the icon is now centered inside the md-button when used with md-table
Removing the margin gives back the `margin:auto` set to the `md-icon` class