### PR TITLE
Added v-on:click (@click) support to md-button

### DIFF
--- a/src/components/mdButton/mdButton.vue
+++ b/src/components/mdButton/mdButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <button class="md-button" :class="[themeClass]" :type="type" :disabled="disabled" v-if="!href">
+  <button class="md-button" :class="[themeClass]" :type="type" :disabled="disabled" v-if="!href" v-on:click.stop="onClick($event)">
     <md-ink-ripple :md-disabled="disabled"></md-ink-ripple>
     <slot></slot>
   </button>
@@ -34,6 +34,11 @@
         }
 
         return this.rel;
+      }
+    },
+    methods: {
+      onClick(event) {
+        this.$emit('click', event);
       }
     }
   };


### PR DESCRIPTION
Since by default a button usually has a click event I feel it is by standard useful to have the native click event sent up via a custom event conforming to what most would expect to work.
Used `v-on:click.stop` to stop the event from causing issues and conflicts between multiple other events
`<md-button @click="alert('Hello World')"></md-button>`
instead of 
`<md-button @click.native="alert('Hello World')"></md-button>`
