### PR TITLE
Fix spelling and grammar in theme docs

### DIFF
--- a/docs/src/pages/themes/DynamicThemes.vue
+++ b/docs/src/pages/themes/DynamicThemes.vue
@@ -2,10 +2,10 @@
   <page-content page-title="Themes - Dynamic Themes">
     <docs-component>
       <div slot="description">
-        <p>Vue Material have a complete theme suite. You can create several themes and apply them on-demand. Like on this documentation website you can set a different theme per-page using the API. But you can have a advanced way to change themes using dynamic themes.</p>
-        <p>You can apply a theme only in a single area of your application using the <code>&lt;md-theme&gt;</code>. If the theme component have only one child element then the theme definition will be attached to this particular element. In other case the component will wrap all of it's children in a <code>&lt;div&gt;</code> tag (or you can customize the output tag).</p>
-        <p>Also every single component in Vue Material suite have a <code>md-theme</code> attribute to set his theme.</p>
-        <p>All the components will inherit all theme properties from it's parents. If the direct parent doesn't have a theme definition the theme will be resolved by its closest parent or the current theme of the entire application.</p>
+        <p>Vue Material have a complete theme suite. You can create several themes and apply them on-demand. Like on this documentation website you can set a different theme per-page using the API. But you can have an advanced way to change themes using dynamic themes.</p>
+        <p>You can apply a theme only in a single area of your application using the <code>&lt;md-theme&gt;</code>. If the theme component has only one child element then the theme definition will be attached to this particular element. In other cases the component will wrap all of its children in a <code>&lt;div&gt;</code> tag (or you can customize the output tag).</p>
+        <p>Also every single component in Vue Material suite have a <code>md-theme</code> attribute to set this theme.</p>
+        <p>All the components will inherit all theme properties from its parents. If the direct parent doesn't have a theme definition the theme will be resolved by its closest parent or the current theme of the entire application.</p>
       </div>
 
       <div slot="api">


### PR DESCRIPTION
Just a few changes. "A" -> "An", "his" -> "This", "it's (it is)" -> "its"
