### PR TITLE
Added "md-stacked" property to md-input-container

### DIFF
--- a/src/components/mdInputContainer/mdInputContainer.scss
+++ b/src/components/mdInputContainer/mdInputContainer.scss
@@ -157,6 +157,20 @@ $input-size: 32px;
     }
   }
 
+  &.md-input-stacked {
+    label {
+      pointer-events: auto;
+      top: 0;
+      opacity: 1;
+      font-size: 12px;
+    }
+
+    input,
+    textarea {
+      font-size: 16px;
+    }
+  }
+
   &.md-has-value {
     input,
     textarea {

--- a/src/components/mdInputContainer/mdInputContainer.vue
+++ b/src/components/mdInputContainer/mdInputContainer.vue
@@ -24,6 +24,7 @@
     name: 'md-input-container',
     props: {
       mdInline: Boolean,
+      mdStacked: Boolean,
       mdHasPassword: Boolean,
       mdClearable: Boolean
     },
@@ -55,7 +56,8 @@
       },
       classes() {
         return {
-          'md-input-inline': this.mdInline,
+          'md-input-inline': this.mdInline && !this.mdStacked,
+          'md-input-stacked': this.mdStacked,
           'md-has-password': this.mdHasPassword,
           'md-clearable': this.mdClearable,
           'md-has-select': this.hasSelect,


### PR DESCRIPTION
Added "md-stacked" property to md-input-container to make a input label stacked

```        
<md-input-container md-theme="red" md-stacked>
   <label>Red - Textarea</label>
   <md-textarea></md-textarea>
</md-input-container>
```
