### PR TITLE
Fix undefined variable in md-radio SCSS

### DIFF
--- a/src/components/mdRadio/mdRadio.scss
+++ b/src/components/mdRadio/mdRadio.scss
@@ -1,7 +1,7 @@
 @import '../../core/stylesheets/variables.scss';
 
 $radio-size: 20px;
-$radio-ripple-size: 48px;
+$radio-touch-size: 48px;
 
 .md-radio {
   width: auto;
@@ -19,8 +19,8 @@ $radio-ripple-size: 48px;
     transition: $swift-ease-out;
 
     &:before {
-      width: $checkbox-touch-size;
-      height: $checkbox-touch-size;
+      width: $radio-touch-size;
+      height: $radio-touch-size;
       position: absolute;
       top: 50%;
       left: 50%;
@@ -57,8 +57,8 @@ $radio-ripple-size: 48px;
       color: rgba(#000, .54);
 
       .md-ripple {
-        width: $radio-ripple-size !important;
-        height: $radio-ripple-size !important;
+        width: $radio-touch-size !important;
+        height: $radio-touch-size !important;
         top: 0 !important;
         right: 0 !important;
         bottom: 0 !important;


### PR DESCRIPTION
Related to #634 

Building the `develop` branch and compiling it using `laravel-mix` produces an unfriendly error message in the browser.

`Error: Module build failed: Error`

This fixes it.