### PR TITLE
Refactor Theme Engine

### DIFF
--- a/src/core/components/mdTheme/dom.js
+++ b/src/core/components/mdTheme/dom.js
@@ -1,0 +1,38 @@
+export var changeHtmlMetaColor;
+export var createNewStyleElement;
+
+if (process.env.VUE_ENV !== 'server') {
+  changeHtmlMetaColor = (color, themeClass, previousClass) => {
+    var elem = document.querySelector('meta[name="theme-color"]');
+
+    if (elem) {
+      elem.setAttribute('content', color);
+    } else {
+      elem = document.createElement('meta');
+      elem.setAttribute('name', 'theme-color');
+      elem.setAttribute('content', color);
+
+      document.head.appendChild(elem);
+    }
+
+    document.body.classList.remove(previousClass);
+    document.body.classList.add(themeClass);
+  };
+
+  createNewStyleElement = (style, styleId) => {
+    const head = document.head;
+    const styleElement = head.querySelector('#' + styleId);
+
+    if (!styleElement) {
+      const newTag = document.createElement('style');
+
+      newTag.type = 'text/css';
+      newTag.id = styleId;
+      newTag.textContent = style;
+
+      head.appendChild(newTag);
+    } else {
+      styleElement.textContent = style;
+    }
+  };
+}

--- a/src/core/components/mdTheme/index.js
+++ b/src/core/components/mdTheme/index.js
@@ -1,8 +1,10 @@
 import palette from './palette';
 import rgba from './rgba';
 import mdTheme from './mdTheme';
+import { changeHtmlMetaColor, createNewStyleElement } from './dom';
 
 const VALID_THEME_TYPE = ['primary', 'accent', 'background', 'warn', 'hue-1', 'hue-2', 'hue-3'];
+const TYPE_REGEX = new RegExp('(' + VALID_THEME_TYPE.join('|').toUpperCase() + ')-(COLOR|CONTRAST)-?(A?\\d*)-?(\\d*\\.?\\d+)?', 'g');
 const DEFAULT_THEME_COLORS = {
   primary: 'indigo',
   accent: 'pink',
@@ -22,170 +24,158 @@ const DEFAULT_THEME_COLORS = {
   }
 };*/
 
-const createNewStyleElement = (style, name) => {
-  let head = document.head;
-  let styleId = 'md-theme-' + name;
-  let styleElement = head.querySelector('#' + styleId);
-
-  if (!styleElement) {
-    let newTag = document.createElement('style');
-
-    style = style.replace(/THEME_NAME/g, styleId);
-
-    newTag.type = 'text/css';
-    newTag.id = styleId;
-    newTag.textContent = style;
-
-    head.appendChild(newTag);
-  } else {
-    styleElement.textContent = style;
-  }
-};
-
-let registeredThemes = [];
-let registeredPrimaryColor = {};
+const registeredPrimaryColor = {};
+const injectedStyles = {};
 
 const parseStyle = (style, theme, name) => {
-  VALID_THEME_TYPE.forEach((type) => {
-    style = style.replace(RegExp('(' + type.toUpperCase() + ')-(COLOR|CONTRAST)-?(A?\\d*)-?(\\d*\\.?\\d+)?', 'g'), (match, paletteType, colorType, hue, opacity) => {
-      let color;
-      let colorVariant = +hue === 0 ? 500 : hue;
+  return style.replace(TYPE_REGEX, (match, type, colorType, hue, opacity) => {
+    let color;
+    let colorVariant = +hue === 0 ? 500 : hue;
 
-      if (theme[type]) {
-        if (typeof theme[type] === 'string') {
-          color = palette[theme[type]];
-        } else {
-          color = palette[theme[type].color] || palette[DEFAULT_THEME_COLORS[type]];
-          colorVariant = +hue === 0 ? theme[type].hue : hue;
-        }
+    type = type.toLowerCase();
+
+    if (theme[type]) {
+      if (typeof theme[type] === 'string') {
+        color = palette[theme[type]];
       } else {
-        color = palette[DEFAULT_THEME_COLORS[type]];
+        color = palette[theme[type].color] || palette[DEFAULT_THEME_COLORS[type]];
+        colorVariant = +hue === 0 ? theme[type].hue : hue;
       }
+    } else {
+      color = palette[DEFAULT_THEME_COLORS[type]];
+    }
 
-      if (colorType === 'COLOR') {
-        let isDefault = palette[theme[type]];
+    if (colorType === 'COLOR') {
+      let isDefault = palette[theme[type]];
 
-        if (!colorVariant && !isDefault) {
-          if (type === 'accent') {
-            colorVariant = 'A200';
-          } else if (type === 'background') {
-            colorVariant = 50;
-          }
-        }
-
-        if (type === 'primary') {
-          registeredPrimaryColor[name] = color[colorVariant];
-        }
-
-        if (opacity) {
-          return rgba(color[colorVariant], opacity);
-        }
-
-        return color[colorVariant];
-      }
-
-      let isDarkText = color.darkText.indexOf(colorVariant) >= 0;
-
-      if (theme[type] && typeof theme[type] !== 'string' && theme[type].textColor) {
-        if (theme[type].textColor === 'black') {
-          isDarkText = true;
-        } else if (theme[type].textColor === 'white') {
-          isDarkText = false;
+      if (!colorVariant && !isDefault) {
+        if (type === 'accent') {
+          colorVariant = 'A200';
+        } else if (type === 'background') {
+          colorVariant = 50;
         }
       }
 
-      if (isDarkText) {
-        if (opacity) {
-          return rgba('#000', opacity);
-        }
-
-        return 'rgba(0, 0, 0, .87)';
+      if (type === 'primary') {
+        registeredPrimaryColor[name] = color[colorVariant];
       }
 
       if (opacity) {
-        return rgba('#fff', opacity);
+        return rgba(color[colorVariant], opacity);
       }
 
-      return 'rgba(255, 255, 255, .87)';
-    });
-  });
+      return color[colorVariant];
+    }
 
-  return style;
+    let isDarkText = color.darkText.indexOf(colorVariant) >= 0;
+
+    if (theme[type] && typeof theme[type] !== 'string' && theme[type].textColor) {
+      if (theme[type].textColor === 'black') {
+        isDarkText = true;
+      } else if (theme[type].textColor === 'white') {
+        isDarkText = false;
+      }
+    }
+
+    if (isDarkText) {
+      if (opacity) {
+        return rgba('#000', opacity);
+      }
+
+      return 'rgba(0, 0, 0, .87)';
+    }
+
+    if (opacity) {
+      return rgba('#fff', opacity);
+    }
+
+    return 'rgba(255, 255, 255, .87)';
+  });
 };
 
-const registerTheme = (theme, name, themeStyles) => {
-  let parsedStyle = [];
+function warnNotFound(themeName) {
+  console.warn(`The theme '${themeName}' doesn't exists. You need to register` +
+    ' it first in order to use.');
+}
 
-  themeStyles.forEach((style) => {
-    parsedStyle.push(parseStyle(style, theme, name));
-  });
+function injectStyle(style, spec, name, styleId) {
+  if (createNewStyleElement) {
+    style = parseStyle(style, spec, name);
+    style = style.replace(/THEME_NAME/g, styleId);
 
-  createNewStyleElement(parsedStyle.join('\n'), name);
-};
-
-const registerAllThemes = (themes, themeStyles) => {
-  let themeNames = themes ? Object.keys(themes) : [];
-
-  themeNames.forEach((name) => {
-    registerTheme(themes[name], name, themeStyles);
-    registeredThemes.push(name);
-  });
-};
-
-const changeHtmlMetaColor = (color) => {
-  let themeColorElement = document.querySelector('meta[name="theme-color"]');
-
-  if (themeColorElement) {
-    themeColorElement.setAttribute('content', color);
-  } else {
-    themeColorElement = document.createElement('meta');
-    themeColorElement.setAttribute('name', 'theme-color');
-    themeColorElement.setAttribute('content', color);
-
-    document.head.appendChild(themeColorElement);
+    createNewStyleElement(style, styleId);
   }
-};
+}
 
 export default function install(Vue) {
   Vue.material = new Vue({
-    data: () => ({
+    data: {
+      currentTheme: 'default',
+      inkRipple: true,
+      prefix: 'md-theme-',
       styles: [],
-      currentTheme: null,
-      inkRipple: true
-    }),
+      themes: {
+        default: DEFAULT_THEME_COLORS
+      }
+    },
+    watch: {
+      styles() {
+        this.refreshInjectedStyles();
+      }
+    },
     methods: {
       registerPalette(name, spec) {
         palette[name] = spec;
       },
+      useTheme(name) {
+        if (name in injectedStyles) {
+          return;
+        }
+        const spec = this.themes[name];
+
+        if (!spec) {
+          return warnNotFound(name);
+        }
+
+        injectStyle(this.styles.join('\n'), spec, name, this.prefix + name);
+
+        return injectedStyles[name] = true;
+      },
+      refreshInjectedStyles() {
+        const styles = this.styles.join('\n');
+        const prefix = this.prefix;
+
+        Object.keys(injectedStyles).forEach((name) => {
+          const spec = this.themes[name];
+
+          injectStyle(styles, spec, name, prefix + name);
+        });
+      },
       registerTheme(name, spec) {
-        let theme = {};
-
         if (typeof name === 'string') {
-          theme[name] = spec;
+          this.themes[name] = spec;
         } else {
-          theme = name;
+          Object.keys(name).forEach((k) => this.themes[k] = name[k]);
+        }
+      },
+      setCurrentTheme(name) {
+        if (name === this.currentTheme) {
+          return;
         }
 
-        registerAllThemes(theme, this.styles);
-      },
-      applyCurrentTheme(themeName) {
-        changeHtmlMetaColor(registeredPrimaryColor[themeName]);
-        document.body.classList.remove('md-theme-' + this.currentTheme);
-        document.body.classList.add('md-theme-' + themeName);
-        this.currentTheme = themeName;
-      },
-      setCurrentTheme(themeName) {
-        if (registeredThemes.indexOf(themeName) >= 0) {
-          this.applyCurrentTheme(themeName);
-        } else {
-          if (registeredThemes.indexOf('default') === -1) {
-            this.registerTheme('default', DEFAULT_THEME_COLORS);
-          } else {
-            console.warn(`The theme '${themeName}' doesn't exists. You need to register it first in order to use.`);
-          }
+        const prefix = this.prefix;
 
-          this.applyCurrentTheme('default');
+        this.useTheme(name);
+
+        if (changeHtmlMetaColor) {
+          changeHtmlMetaColor(
+            registeredPrimaryColor[name],
+            prefix + this.currentTheme,
+            prefix + name
+          );
         }
+
+        this.currentTheme = name;
       }
     }
   });

--- a/src/core/components/mdTheme/mdTheme.vue
+++ b/src/core/components/mdTheme/mdTheme.vue
@@ -8,17 +8,26 @@
         default: 'default'
       }
     },
-    data: () => ({
-      name: 'md-theme'
-    }),
-    render(render) {
+    render(createElement) {
       if (this.mdTag || this.$slots.default.length > 1) {
-        return render(this.mdTag || 'div', {
-          staticClass: 'md-theme'
+        return createElement(this.mdTag || 'div', {
+          staticClass: this.$material.prefix + this.mdName
         }, this.$slots.default);
       }
 
       return this.$slots.default[0];
+    },
+    watch: {
+      mdName(value) {
+        this.$material.useTheme(value);
+      }
+    },
+    beforeMount() {
+      const localTheme = this.mdName;
+
+      if (localTheme) {
+        this.$material.useTheme(localTheme);
+      }
     }
   };
 </script>

--- a/src/core/components/mdTheme/mixin.js
+++ b/src/core/components/mdTheme/mixin.js
@@ -1,47 +1,43 @@
+// Theme mixin
+
+// Grab the closest ancestor component's `md-theme` attribute OR grab the
+// `md-name` attribute from an `<md-theme>` component.
+function getAncestorThemeName(component) {
+  if (!component) {
+    return null;
+  }
+
+  let name = component.mdTheme;
+
+  if (!name && component.$options._componentTag === 'md-theme') {
+    name = component.mdName;
+  }
+
+  return name || getAncestorThemeName(component.$parent);
+}
+
 export default {
   props: {
     mdTheme: String
   },
-  data: () => ({
-    closestThemedParent: false
-  }),
-  methods: {
-    getClosestThemedParent($parent) {
-      if (!$parent || !$parent.$el || $parent._uid === 0) {
-        return false;
-      }
-
-      if ($parent.mdTheme || $parent.mdName) {
-        return $parent;
-      }
-
-      return this.getClosestThemedParent($parent.$parent);
-    }
-  },
   computed: {
+    mdEffectiveTheme() {
+      return getAncestorThemeName(this) || this.$material.currentTheme;
+    },
     themeClass() {
-      if (this.mdTheme) {
-        return 'md-theme-' + this.mdTheme;
-      }
-
-      let theme = this.closestThemedParent.mdTheme;
-
-      if (!theme) {
-        if (this.closestThemedParent) {
-          theme = this.closestThemedParent.mdName;
-        } else {
-          theme = this.$material.currentTheme;
-        }
-      }
-
-      return 'md-theme-' + theme;
+      return this.$material.prefix + this.mdEffectiveTheme;
     }
   },
-  mounted() {
-    this.closestThemedParent = this.getClosestThemedParent(this.$parent);
+  watch: {
+    mdTheme(value) {
+      this.$material.useTheme(value);
+    }
+  },
+  beforeMount() {
+    const localTheme = this.mdTheme;
 
-    if (!this.$material.currentTheme) {
-      this.$material.setCurrentTheme('default');
+    if (localTheme) {
+      this.$material.useTheme(localTheme);
     }
   }
 };


### PR DESCRIPTION
This is a first step toward supporting Server-side Rendering (SSR). Several other components still depend on `document` always being available, those will need to be fixed eventually. This PR will at least eliminate the theme engine as a bottleneck.

- Optimize parseStyle method to run a single RegExp replace
- Abstract DOM manipulation to check for VUE_ENV first
- Add theme name to `<md-theme>` element when it would render its own tag
- Recompute styles when a new set of selectors is added (via styles.push)
- Use computed property to find closest themed ancestor for mixin
- Only grab md-name attribute from an md-theme component (`<md-table-edit>` uses the md-name attribute for <input> tags)