### PR TITLE
Add back click bubbling

### DIFF
--- a/src/components/mdButton/mdButton.vue
+++ b/src/components/mdButton/mdButton.vue
@@ -1,10 +1,19 @@
 <template>
-  <button class="md-button" :class="[themeClass]" :type="type" :disabled="disabled" v-if="!href">
+  <button class="md-button" :class="[themeClass]" :type="type"
+    :disabled="disabled"
+    @click="$emit('click', $event)"
+    v-if="!href"
+  >
     <md-ink-ripple :md-disabled="disabled"></md-ink-ripple>
     <slot></slot>
   </button>
 
-  <a class="md-button" :class="[themeClass]" :href="href" :disabled="disabled" :target="target" :rel="newRel" v-else>
+  <a class="md-button" :class="[themeClass]" :href="href" :disabled="disabled"
+    :target="target"
+    :rel="newRel"
+    @click="$emit('click', $event)"
+    v-else
+  >
     <md-ink-ripple :md-disabled="disabled"></md-ink-ripple>
     <slot></slot>
   </a>


### PR DESCRIPTION
When using the button component as part of a `<router-link tag="md-button">` the
event will not be attached to listen natively. Clicking on the button will not activate
the link.

```html
<!-- From the documentation -->
<router-link tag="md-button" to="/components/button" class="md-raised md-primary">Router Link</router-link>
```

Re-emitting the native event as a component event fixes the issue.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/marcosmoura/vue-material/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->
