### PR TITLE
Fixes #629 Unable to set disabled property of md-bottom-bar-item

### DIFF
--- a/src/components/mdBottomBar/mdBottomBarItem.vue
+++ b/src/components/mdBottomBar/mdBottomBarItem.vue
@@ -29,7 +29,7 @@
       mdIconSrc: String,
       mdIconset: String,
       mdActive: Boolean,
-      disabled: String,
+      disabled: Boolean,
       href: String
     },
     data() {


### PR DESCRIPTION
Setting to disabled to type Boolean, which fixes the errors reported in #629 :
<img width="445" alt="screenshot 2017-04-18 23 52 35" src="https://cloud.githubusercontent.com/assets/2807807/25163882/09e641ce-2493-11e7-8aa6-464950ae6abc.png">
