### PR TITLE
Dont overwrite currentSize of mdTablePagination

### DIFF
--- a/src/components/mdTable/mdTablePagination.vue
+++ b/src/components/mdTable/mdTablePagination.vue
@@ -49,7 +49,7 @@
         subTotal: 0,
         totalItems: 0,
         currentPage: 1,
-        currentSize: this.mdSize
+        currentSize: parseInt(this.mdSize, 10)
       };
     },
     watch: {

--- a/src/components/mdTable/mdTablePagination.vue
+++ b/src/components/mdTable/mdTablePagination.vue
@@ -49,7 +49,7 @@
         subTotal: 0,
         totalItems: 0,
         currentPage: 1,
-        currentSize: 0
+        currentSize: this.mdSize
       };
     },
     watch: {

--- a/src/components/mdTable/mdTablePagination.vue
+++ b/src/components/mdTable/mdTablePagination.vue
@@ -108,7 +108,7 @@
       this.$nextTick(() => {
         this.subTotal = this.currentPage * this.currentSize;
         this.mdPageOptions = this.mdPageOptions || [10, 25, 50, 100];
-        this.currentSize = this.mdPageOptions[0];
+        this.currentSize = this.mdPageOptions.includes(this.currentSize) ? this.currentSize : this.mdPageOptions[0];
         this.canFireEvents = true;
       });
     }


### PR DESCRIPTION
No matter what value you define as `md-size` option on `md-table-pagination`, it is overridden by the first value in the `md-page-options`.

It was not possible to define pagination options with `[10, 25, 50, 100]` and define the default start size as `25`.