### PR TITLE
DOCS: Added missing argument in code example

### DIFF
--- a/docs/src/pages/components/Dialog.vue
+++ b/docs/src/pages/components/Dialog.vue
@@ -534,6 +534,7 @@
                 :md-cancel-text=&quot;prompt.cancel&quot;
                 @open=&quot;onOpen&quot;
                 @close=&quot;onClose&quot;
+                v-model=&quot;prompt.value&quot;
                 ref=&quot;dialog6&quot;&gt;
               &lt;/md-dialog-prompt&gt;
 


### PR DESCRIPTION
Tried one of the code examples and noticed that Vue gave the following warning:

```
[Vue warn]: Missing required prop: "value" 
(found in <MdDialogPrompt>)
```

Added missing argument in code example.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/marcosmoura/vue-material/blob/master/.github/CONTRIBUTING.md#pull-request-guidelines
-->
