### PR TITLE
Adding click handler to mdRadio

### DIFF
--- a/src/components/mdRadio/mdRadio.vue
+++ b/src/components/mdRadio/mdRadio.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="md-radio" :class="[themeClass, classes]">
     <div class="md-radio-container" @click="toggleCheck">
-      <input type="radio" :name="name" :id="id" :disabled="disabled" :value="value">
+      <input type="radio" :name="name" :id="id" :disabled="disabled" :value="value" @click="toggleCheck">
       <md-ink-ripple :md-disabled="disabled" />
     </div>
 


### PR DESCRIPTION
This is a tiny patch helps to address a really strange edge case I discovered testing with PhantomJS.

Take the following instance template:
```
    <md-radio v-model="selected"
        id="first-option"
        class="e2e-first-option"
        md-value="1"
        name="group-1">
        Option One
    </md-radio>
```

Under test the following will work as intended in Chrome:
```
vm.$el.querySelector('#e2e-first-option').click()
```

... But the same `click` *does not trigger the handler* as intended in PhantomJS. Instead, you need to use something like:
```
vm.$el.querySelector('.e2e-first-option > .md-radio-container').click()
```

So a workaround exists, but it's pretty unintuitive without digging into the source for the radio component.